### PR TITLE
tweak search settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and `Removed`.
 - Optional 'Categories' column for Catalog.
 - Optional 'Summary' column for My Addons.
 
+## Changed
+
+- Tweaked catalog fuzzy search to weight title matches higher than description
+  matches
+
 ## [0.7.0] - 2021-01-26
 
 ### Added

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2451,20 +2451,26 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
             .iter()
             .filter(|a| !a.game_versions.is_empty())
             .filter_map(|a| {
-                let title_and_summary = format!("{} {}", a.name, a.summary);
-
                 if let Some(query) = &query {
-                    if let Some(score) = fuzzy_matcher.fuzzy_match(&title_and_summary, &query) {
-                        Some((a, score))
+                    let title_score = fuzzy_matcher
+                        .fuzzy_match(&a.name, &query)
+                        .unwrap_or_default();
+                    let description_score = fuzzy_matcher
+                        .fuzzy_match(&a.summary, &query)
+                        .unwrap_or_default()
+                        / 2;
+
+                    let max_score = title_score.max(description_score);
+
+                    if max_score > 0 {
+                        Some((a, max_score))
                     } else {
                         None
                     }
                 } else {
-                    Some((a, 1))
+                    Some((a, 0))
                 }
             })
-            // Only return positive scores
-            .filter(|(_, s)| *s > 0)
             .filter(|(a, _)| {
                 a.game_versions
                     .iter()


### PR DESCRIPTION
Resolves #517 

## Proposed Changes
  - Score title and description separately, with a higher weighting to title. Use the max of those 2 scores.
  - This should help sort the matches better on title first, which is more relevant generally to what the user wants to see

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
