### PR TITLE
add support for townlong-yak addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and `Removed`.
 
 ### Added
 
+- Townlong Yak addons has been added to the Catalog.
 - Optional 'Categories' column for Catalog.
 - Optional 'Summary' column for My Addons.
 - New languages added to Ajour:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "ajour"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ajour-core",
  "ajour-weak-auras",

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -219,7 +219,8 @@ impl Addon {
                         RepositoryKind::WowI => {
                             self.repository_id() == f.repository_identifiers.wowi.as_deref()
                         }
-                        // For git sources, prioritize the folder that has a version in it
+                        // For git & townlong sources, prioritize the folder that has a version in it
+                        RepositoryKind::TownlongYak => f.version.is_some(),
                         RepositoryKind::Git(_) => f.version.is_some(),
                     }
                 } else {
@@ -271,6 +272,13 @@ impl Addon {
     pub fn set_version(&mut self, version: String) {
         if let Some(metadata) = self.repository.as_mut().map(|r| &mut r.metadata) {
             metadata.version = Some(version);
+        }
+    }
+
+    /// Sets the file id of the addon
+    pub fn set_file_id(&mut self, file_id: i64) {
+        if let Some(metadata) = self.repository.as_mut().map(|r| &mut r.metadata) {
+            metadata.file_id = Some(file_id);
         }
     }
 
@@ -410,6 +418,17 @@ impl Addon {
             self.primary_addon_folder()
                 .map(|f| f.repository_identifiers.wowi.as_deref())
                 .flatten()
+        }
+    }
+
+    /// Returns the hub id of the addon, if applicable.
+    pub fn hub_id(&self) -> Option<i32> {
+        if self.repository_kind() == Some(RepositoryKind::TownlongYak) {
+            self.repository()
+                .map(|r| r.id.parse::<i32>().ok())
+                .flatten()
+        } else {
+            None
         }
     }
 

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -7,7 +7,7 @@ use chrono::prelude::*;
 use isahc::ResponseExt;
 use serde::{Deserialize, Serialize};
 
-const CATALOG_URL: &str = "https://github.com/ajour/ajour-catalog/raw/master/catalog.json";
+const CATALOG_URL: &str = "https://raw.githubusercontent.com/ajour/ajour-catalog/3ce1414498adbc7167f11fe0dac7cd58e7b55391/catalog.json";
 
 type Etag = Option<String>;
 
@@ -65,6 +65,8 @@ pub enum Source {
     Tukui,
     #[serde(alias = "wowi")]
     WowI,
+    #[serde(alias = "townlong-yak")]
+    TownlongYak,
 }
 
 impl std::fmt::Display for Source {
@@ -73,6 +75,7 @@ impl std::fmt::Display for Source {
             Source::Curse => "Curse",
             Source::Tukui => "Tukui",
             Source::WowI => "WowInterface",
+            Source::TownlongYak => "TownlongYak",
         };
         write!(f, "{}", s)
     }

--- a/crates/core/src/config/wow.rs
+++ b/crates/core/src/config/wow.rs
@@ -49,6 +49,14 @@ impl Flavor {
         }
     }
 
+    /// Returns flavor `String` in WowUp.Hub format
+    pub(crate) fn hub_format(self) -> String {
+        match self {
+            Flavor::Retail | Flavor::RetailPTR | Flavor::RetailBeta => "retail".to_owned(),
+            Flavor::Classic | Flavor::ClassicPTR => "classic".to_owned(),
+        }
+    }
+
     /// Returns `Flavor` which self relates to.
     pub fn base_flavor(self) -> Flavor {
         match self {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -79,6 +79,8 @@ pub enum RepositoryError {
     CurseMissingPackage { id: String },
     #[error("No package found for WowI id {id}")]
     WowIMissingPackage { id: String },
+    #[error("No package found for Hub id {id}")]
+    HubMissingPackage { id: String },
     #[error("No remote package found for channel {channel}")]
     MissingPackageChannel { channel: ReleaseChannel },
     #[error("Git repo must be created with `from_source_url`")]

--- a/crates/core/src/repository/backend/mod.rs
+++ b/crates/core/src/repository/backend/mod.rs
@@ -6,11 +6,13 @@ use dyn_clone::{clone_trait_object, DynClone};
 
 pub mod curse;
 mod git;
+pub mod townlongyak;
 pub mod tukui;
 pub mod wowi;
 
 pub use curse::Curse;
 pub use git::{Github, Gitlab};
+pub use townlongyak::TownlongYak;
 pub use tukui::Tukui;
 pub use wowi::WowI;
 

--- a/crates/core/src/repository/backend/townlongyak.rs
+++ b/crates/core/src/repository/backend/townlongyak.rs
@@ -1,0 +1,146 @@
+use super::*;
+use crate::config::Flavor;
+use crate::error::{DownloadError, RepositoryError};
+use crate::network::post_json_async;
+use crate::repository::{ReleaseChannel, RemotePackage};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use isahc::ResponseExt;
+use serde::{Deserialize, Serialize};
+
+use std::collections::HashMap;
+
+const API_ENDPOINT: &str = "https://hub.wowup.io";
+
+#[derive(Debug, Clone)]
+pub struct TownlongYak {
+    pub id: String,
+    pub flavor: Flavor,
+}
+
+#[async_trait]
+impl Backend for TownlongYak {
+    async fn get_metadata(&self) -> Result<RepositoryMetadata, RepositoryError> {
+        let packages = fetch_remote_packages(self.flavor, &[self.id.clone()]).await?;
+
+        let package = packages
+            .into_iter()
+            .next()
+            .ok_or(RepositoryError::HubMissingPackage {
+                id: self.id.clone(),
+            })?;
+
+        let metadata = metadata_from_townlong_package(self.flavor, package);
+
+        Ok(metadata)
+    }
+
+    async fn get_changelog(
+        &self,
+        _file_id: Option<i64>,
+        _tag_name: Option<String>,
+    ) -> Result<Option<String>, RepositoryError> {
+        Ok(None)
+    }
+}
+
+pub(crate) fn metadata_from_townlong_package(
+    flavor: Flavor,
+    package: TownlongYakPackage,
+) -> RepositoryMetadata {
+    let mut remote_packages = HashMap::new();
+
+    for release in package.releases.iter() {
+        if release.game_type == flavor.hub_format() {
+            let version = release.tag_name.clone();
+            let download_url = release.download_url.clone();
+            let date_time = Some(release.published_at);
+
+            let package = RemotePackage {
+                version,
+                download_url,
+                date_time,
+                file_id: Some(release.id),
+                modules: vec![],
+            };
+
+            if release.prerelease {
+                remote_packages.insert(ReleaseChannel::Beta, package);
+            } else {
+                remote_packages.insert(ReleaseChannel::Stable, package);
+            }
+        }
+    }
+
+    let mut metadata = RepositoryMetadata::empty();
+    metadata.remote_packages = remote_packages;
+    metadata.website_url = Some(package.repository.clone());
+    metadata.title = Some(package.repository_name);
+    metadata.author = package.owner_name;
+
+    metadata
+}
+
+/// Function to fetch a remote addon package which contains
+/// information about the addon on the repository.
+pub(crate) async fn fetch_remote_packages(
+    flavor: Flavor,
+    ids: &[String],
+) -> Result<Vec<TownlongYakPackage>, DownloadError> {
+    let url = format!("{}/addons/batch/{}", API_ENDPOINT, flavor.hub_format());
+
+    let addon_ids = ids.iter().filter_map(|i| i.parse::<i64>().ok()).collect();
+
+    let timeout = Some(30);
+
+    let mut resp = post_json_async(&url, BatchRequest { addon_ids }, vec![], timeout).await?;
+
+    if resp.status().is_success() {
+        let packages = resp.json::<TownlongYakBatchResponse>().map(|r| r.addons);
+
+        Ok(packages?)
+    } else {
+        Err(DownloadError::InvalidStatusCode {
+            code: resp.status(),
+            url,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct TownlongYakBatchResponse {
+    pub addons: Vec<TownlongYakPackage>,
+    pub count: i64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+/// Struct for applying wowi details to an `Addon`.
+pub struct TownlongYakPackage {
+    pub id: i64,
+    pub repository: String,
+    pub repository_name: String,
+    pub source: String,
+    pub description: Option<String>,
+    pub homepage: Option<String>,
+    pub owner_name: Option<String>,
+    pub releases: Vec<TownlongYakRelease>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct TownlongYakRelease {
+    pub id: i64,
+    pub download_url: String,
+    pub game_type: String,
+    pub game_version: String,
+    pub tag_name: String,
+    pub published_at: DateTime<Utc>,
+    #[serde(default)]
+    pub prerelease: bool,
+}
+
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Serialize)]
+struct BatchRequest {
+    addon_ids: Vec<i64>,
+}

--- a/crates/core/src/repository/mod.rs
+++ b/crates/core/src/repository/mod.rs
@@ -11,14 +11,15 @@ use std::collections::HashMap;
 mod backend;
 use backend::Backend;
 
-pub use backend::{curse, tukui, wowi};
-use backend::{Curse, Github, Gitlab, Tukui, WowI};
+pub use backend::{curse, townlongyak, tukui, wowi};
+use backend::{Curse, Github, Gitlab, TownlongYak, Tukui, WowI};
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize)]
 pub enum RepositoryKind {
     Curse,
     Tukui,
     WowI,
+    TownlongYak,
     Git(GitKind),
 }
 
@@ -31,6 +32,7 @@ impl std::fmt::Display for RepositoryKind {
                 RepositoryKind::WowI => "WoWInterface",
                 RepositoryKind::Tukui => "Tukui",
                 RepositoryKind::Curse => "CurseForge",
+                RepositoryKind::TownlongYak => "TownlongYak",
                 RepositoryKind::Git(git) => match git {
                     GitKind::Github => "GitHub",
                     GitKind::Gitlab => "GitLab",
@@ -121,6 +123,10 @@ impl RepositoryPackage {
                 flavor,
             }),
             RepositoryKind::Tukui => Box::new(Tukui {
+                id: id.clone(),
+                flavor,
+            }),
+            RepositoryKind::TownlongYak => Box::new(TownlongYak {
                 id: id.clone(),
                 flavor,
             }),

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1844,7 +1844,7 @@ impl std::fmt::Display for CatalogSource {
                 catalog::Source::Curse => "Curse",
                 catalog::Source::Tukui => "Tukui",
                 catalog::Source::WowI => "WowInterface",
-                catalog::Source::TownlongYak => "TownlongYak",
+                catalog::Source::TownlongYak => "Townlong-Yak",
             },
         };
         write!(f, "{}", s)

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -851,9 +851,14 @@ impl Application for Ajour {
 
                         // TODO (tarkah): We should make this prettier with new sources coming in.
                         let installed_for_flavor = addons.iter().any(|a| {
-                            a.curse_id() == Some(addon.addon.id)
-                                || a.tukui_id() == Some(&addon.addon.id.to_string())
-                                || a.wowi_id() == Some(&addon.addon.id.to_string())
+                            (a.curse_id() == Some(addon.addon.id)
+                                && addon.addon.source == catalog::Source::Curse)
+                                || (a.tukui_id() == Some(&addon.addon.id.to_string())
+                                    && addon.addon.source == catalog::Source::Tukui)
+                                || (a.wowi_id() == Some(&addon.addon.id.to_string())
+                                    && addon.addon.source == catalog::Source::WowI)
+                                || (a.hub_id() == Some(addon.addon.id)
+                                    && addon.addon.source == catalog::Source::TownlongYak)
                         });
 
                         let install_addon = install_addons.iter().find(|a| {
@@ -1827,6 +1832,7 @@ impl CatalogSource {
             CatalogSource::Choice(catalog::Source::Curse),
             CatalogSource::Choice(catalog::Source::Tukui),
             CatalogSource::Choice(catalog::Source::WowI),
+            CatalogSource::Choice(catalog::Source::TownlongYak),
         ]
     }
 }
@@ -1838,6 +1844,7 @@ impl std::fmt::Display for CatalogSource {
                 catalog::Source::Curse => "Curse",
                 catalog::Source::Tukui => "Tukui",
                 catalog::Source::WowI => "WowInterface",
+                catalog::Source::TownlongYak => "TownlongYak",
             },
         };
         write!(f, "{}", s)

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -757,15 +757,16 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
                 addon.state = AddonState::Fingerprint;
 
-                let mut version = None;
+                // Set version & file id of installed addon to that of newly unpacked package.
                 if let Some(package) = addon.relevant_release_package(global_release_channel) {
-                    version = Some(package.version);
-                }
-                if let Some(version) = version {
-                    addon.set_version(version);
+                    addon.set_version(package.version);
+
+                    if let Some(file_id) = package.file_id {
+                        addon.set_file_id(file_id);
+                    }
                 }
 
-                // If we are updating / installing a Tukui / WowI
+                // If we are updating / installing a Tukui / WowI / Townlong / Git
                 // addon, we want to update the cache. If we are installing a Curse
                 // addon, we want to make sure cache entry exists for those folders
                 if let Some(addon_cache) = &ajour.addon_cache {
@@ -781,6 +782,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                             // Update the entry for this cached addon
                             Some(RepositoryKind::Tukui)
                             | Some(RepositoryKind::WowI)
+                            | Some(RepositoryKind::TownlongYak)
                             | Some(RepositoryKind::Git(_)) => {
                                 commands.push(Command::perform(
                                     update_addon_cache(addon_cache.clone(), entry, flavor),
@@ -2131,6 +2133,7 @@ async fn perform_fetch_latest_addon(
                     catalog::Source::Curse => RepositoryKind::Curse,
                     catalog::Source::Tukui => RepositoryKind::Tukui,
                     catalog::Source::WowI => RepositoryKind::WowI,
+                    catalog::Source::TownlongYak => RepositoryKind::TownlongYak,
                 };
 
                 RepositoryPackage::from_repo_id(flavor, kind, id)?


### PR DESCRIPTION
Resolves #512 

## Proposed Changes
  - Add townlong-yak addon support via the hub api

## Checklist

- [x] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
