### PR TITLE
fix: format townlong-yak game versions

### DIFF
--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -8,6 +8,7 @@ use crate::{
     repository::{
         curse, townlongyak, tukui, wowi, RepositoryIdentifiers, RepositoryKind, RepositoryPackage,
     },
+    utility::format_interface_into_game_version,
 };
 use async_std::sync::{Arc, Mutex};
 use fancy_regex::Regex;
@@ -1258,19 +1259,6 @@ fn split_dependencies_into_vec(value: &str) -> Vec<String> {
         .collect()
 }
 
-fn format_interface_into_game_version(interface: &str) -> String {
-    if interface.len() == 5 {
-        let major = interface[..1].parse::<u8>();
-        let minor = interface[1..3].parse::<u8>();
-        let patch = interface[3..5].parse::<u8>();
-        if let (Ok(major), Ok(minor), Ok(patch)) = (major, minor, patch) {
-            return format!("{}.{}.{}", major, minor, patch);
-        }
-    }
-
-    interface.to_owned()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1309,17 +1297,5 @@ mod tests {
 
         let title = RE_TOC_TITLE.replace_all("|cff1784d1ElvUI |cff83F3F7Absorb Tags", "$1");
         assert_eq!(title, "ElvUI Absorb Tags");
-    }
-
-    #[test]
-    fn test_interface() {
-        let interface = "90001";
-        assert_eq!("9.0.1", format_interface_into_game_version(interface));
-
-        let interface = "11305";
-        assert_eq!("1.13.5", format_interface_into_game_version(interface));
-
-        let interface = "100000";
-        assert_eq!("100000", format_interface_into_game_version(interface));
     }
 }

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -15,6 +15,23 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+/// Takes a `&str` and formats it into a proper
+/// World of Warcraft release version.
+///
+/// Eg. 90001 would be 9.0.1.
+pub fn format_interface_into_game_version(interface: &str) -> String {
+    if interface.len() == 5 {
+        let major = interface[..1].parse::<u8>();
+        let minor = interface[1..3].parse::<u8>();
+        let patch = interface[3..5].parse::<u8>();
+        if let (Ok(major), Ok(minor), Ok(patch)) = (major, minor, patch) {
+            return format!("{}.{}.{}", major, minor, patch);
+        }
+    }
+
+    interface.to_owned()
+}
+
 /// Takes a `&str` and strips any non-digit.
 /// This is used to unify and compare addon versions:
 ///
@@ -323,5 +340,20 @@ mod tests {
             root_alternate_path.eq(&wow_path_resolution(Some(classic_alternate_path)).unwrap()),
             true
         );
+    }
+
+    #[test]
+    fn test_interface() {
+        let interface = "90001";
+        assert_eq!("9.0.1", format_interface_into_game_version(interface));
+
+        let interface = "11305";
+        assert_eq!("1.13.5", format_interface_into_game_version(interface));
+
+        let interface = "100000";
+        assert_eq!("100000", format_interface_into_game_version(interface));
+
+        let interface = "9.0.1";
+        assert_eq!("9.0.1", format_interface_into_game_version(interface));
     }
 }

--- a/src/gui/element/catalog.rs
+++ b/src/gui/element/catalog.rs
@@ -6,7 +6,8 @@ use {
     },
     crate::localization::{localized_string, localized_timeago_formatter},
     ajour_core::{
-        config::Config, theme::ColorPalette, utility::format_interface_into_game_version,
+        catalog::Source, config::Config, theme::ColorPalette,
+        utility::format_interface_into_game_version,
     },
     ajour_widgets::{header, Header, TableRow},
     chrono::prelude::*,
@@ -278,7 +279,10 @@ pub fn data_row_container<'a, 'b>(
             .game_versions
             .iter()
             .find(|gv| gv.flavor == config.wow.flavor.base_flavor())
-            .map(|gv| format_interface_into_game_version(&gv.game_version[..]))
+            .map(|gv| match addon_data.source {
+                Source::TownlongYak => format_interface_into_game_version(&gv.game_version[..]),
+                _ => gv.game_version.clone(),
+            })
             .unwrap_or_else(|| "-".to_owned());
 
         let game_version_text = Text::new(game_version_text).size(DEFAULT_FONT_SIZE);

--- a/src/gui/element/catalog.rs
+++ b/src/gui/element/catalog.rs
@@ -278,8 +278,7 @@ pub fn data_row_container<'a, 'b>(
             .game_versions
             .iter()
             .find(|gv| gv.flavor == config.wow.flavor.base_flavor())
-            .map(|gv| gv.game_version.clone())
-            .map(|gv| format_interface_into_game_version(&gv[..]))
+            .map(|gv| format_interface_into_game_version(&gv.game_version[..]))
             .unwrap_or_else(|| "-".to_owned());
 
         let game_version_text = Text::new(game_version_text).size(DEFAULT_FONT_SIZE);

--- a/src/gui/element/catalog.rs
+++ b/src/gui/element/catalog.rs
@@ -5,7 +5,9 @@ use {
         InstallKind, InstallStatus, Interaction, Message, Mode, SortDirection,
     },
     crate::localization::{localized_string, localized_timeago_formatter},
-    ajour_core::{config::Config, theme::ColorPalette},
+    ajour_core::{
+        config::Config, theme::ColorPalette, utility::format_interface_into_game_version,
+    },
     ajour_widgets::{header, Header, TableRow},
     chrono::prelude::*,
     iced::{Align, Button, Container, Element, Length, Row, Space, Text},
@@ -277,6 +279,7 @@ pub fn data_row_container<'a, 'b>(
             .iter()
             .find(|gv| gv.flavor == config.wow.flavor.base_flavor())
             .map(|gv| gv.game_version.clone())
+            .map(|gv| format_interface_into_game_version(&gv[..]))
             .unwrap_or_else(|| "-".to_owned());
 
         let game_version_text = Text::new(game_version_text).size(DEFAULT_FONT_SIZE);


### PR DESCRIPTION
Formats the townlong-yak game versions from catalog into the what we use the other places.

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
