### PR TITLE
fix: catalog source fallback

### DIFF
--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -67,6 +67,8 @@ pub enum Source {
     WowI,
     #[serde(alias = "townlong-yak")]
     TownlongYak,
+    #[serde(other)]
+    Other,
 }
 
 impl std::fmt::Display for Source {
@@ -76,6 +78,9 @@ impl std::fmt::Display for Source {
             Source::Tukui => "Tukui",
             Source::WowI => "WowInterface",
             Source::TownlongYak => "TownlongYak",
+
+            // This is a fallback option.
+            Source::Other => "Unknown",
         };
         write!(f, "{}", s)
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1845,6 +1845,7 @@ impl std::fmt::Display for CatalogSource {
                 catalog::Source::Tukui => "Tukui",
                 catalog::Source::WowI => "WowInterface",
                 catalog::Source::TownlongYak => "Townlong-Yak",
+                catalog::Source::Other => panic!("Unspported catalog source"),
             },
         };
         write!(f, "{}", s)

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2134,6 +2134,7 @@ async fn perform_fetch_latest_addon(
                     catalog::Source::Tukui => RepositoryKind::Tukui,
                     catalog::Source::WowI => RepositoryKind::WowI,
                     catalog::Source::TownlongYak => RepositoryKind::TownlongYak,
+                    catalog::Source::Other => panic!("Unspported catalog source"),
                 };
 
                 RepositoryPackage::from_repo_id(flavor, kind, id)?


### PR DESCRIPTION
This will resolve the us being able to keep adding sources to the catalog without breaking as just happened.

## Checklist

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
