### PR TITLE
fix: empty flavor folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and `Removed`.
 ### Fixed
 
 - Multiple error messages are now correctly localized.
+- Corrected error in flavor detection if Ajour was launched before WoW had ever
+  been launched. 
 
 ## [0.7.0] - 2021-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and `Removed`.
 
 - Multiple error messages are now correctly localized.
 - Corrected error in flavor detection if Ajour was launched before WoW had ever
-  been launched. 
+  been launched.
 
 ## [0.7.0] - 2021-01-26
 

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -56,6 +56,18 @@ pub struct Config {
 }
 
 impl Config {
+    /// Returns a `Option<PathBuf>` to the falvor directory.
+    /// This will return `None` if no `wow_directory` is set in the config.
+    pub fn get_flavor_directory(&self, flavor: &Flavor) -> Option<PathBuf> {
+        match &self.wow.directory {
+            Some(dir) => {
+                let flavor_dir = dir.join(&flavor.folder_name());
+                Some(flavor_dir)
+            }
+            None => None,
+        }
+    }
+
     /// Returns a `Option<PathBuf>` to the directory containing the addons.
     /// This will return `None` if no `wow_directory` is set in the config.
     pub fn get_addon_directory_for_flavor(&self, flavor: &Flavor) -> Option<PathBuf> {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -656,6 +656,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
 
             if let Some(addon) = addon {
+                // TODO this should be changed
                 let from_directory = ajour
                     .config
                     .get_download_directory_for_flavor(flavor)

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -656,7 +656,6 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
 
             if let Some(addon) = addon {
-                // TODO this should be changed
                 let from_directory = ajour
                     .config
                     .get_download_directory_for_flavor(flavor)


### PR DESCRIPTION
Resolves #528 

## Proposed Changes
  - Ajour will now try to create `Interface/Addon` if they don't exists in flavor directory.

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
