### PR TITLE
fix: update cache when download townlong addons

### DIFF
--- a/src/command/update_addons.rs
+++ b/src/command/update_addons.rs
@@ -208,6 +208,15 @@ async fn update_addon(
         }
     }
 
+    // Set version & file id of installed addon to that of newly unpacked package.
+    if let Some(package) = addon.relevant_release_package(global_release_channel) {
+        addon.set_version(package.version);
+
+        if let Some(file_id) = package.file_id {
+            addon.set_file_id(file_id);
+        }
+    }
+
     // Update cache for addon
     if addon.repository_kind() == Some(RepositoryKind::Tukui)
         || addon.repository_kind() == Some(RepositoryKind::WowI)

--- a/src/command/update_addons.rs
+++ b/src/command/update_addons.rs
@@ -211,6 +211,7 @@ async fn update_addon(
     // Update cache for addon
     if addon.repository_kind() == Some(RepositoryKind::Tukui)
         || addon.repository_kind() == Some(RepositoryKind::WowI)
+        || addon.repository_kind() == Some(RepositoryKind::TownlongYak)
         || matches!(addon.repository_kind(), Some(RepositoryKind::Git(_)))
     {
         if let Ok(entry) = AddonCacheEntry::try_from(&addon) {


### PR DESCRIPTION
Resolves: 
Running CLI update when theres updates for TownlongYak addons kept saying they could be updated.
It seems to be because we dont update the cache. Can you confirm this, @tarkah?

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
