### PR TITLE
fix: wording in weakauras

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2102,7 +2102,7 @@ impl std::fmt::Display for AuraStatus {
         let s = if let Some(key) = match self.0 {
             Idle => None,
             UpdateAvailable => Some("weakaura-update-available"),
-            UpdateQueued => Some("weakaura-update-queued"),
+            UpdateQueued => Some("completed"),
         } {
             localized_string(key)
         } else {

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -184,6 +184,7 @@ mod test {
         update_all: String,
         ajour_update_channel: String,
         updating: String,
+        weakaura_update_available: String,
         weakaura_updates_queued: String,
         weakauras_loaded: String,
         website: String,


### PR DESCRIPTION
Resolves:
I don't like the way we worded WeakAura updates. I think we should move to "Completed" just like addons and then still leave the  "Finish ingame" message we have:

![weakaura_fix](https://user-images.githubusercontent.com/2248455/108513652-2d5a1680-72c3-11eb-984a-7bbf83d70d5e.PNG)

## Checklist

- [x] Update terms on POEditor (remove weakaura-update-queued)
- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
