### PR TITLE
For users with only a single account, automatically pick the account when in the weak aura view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and `Removed`.
 
 ## [Unreleased]
 
+- Automatically select account in My WeakAuras if there only is one account
+
 ## [0.7.1] - 2021-02-14
 
 ### Added

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1875,9 +1875,16 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 let state = ajour.weak_auras_state.entry(flavor).or_default();
                 state.accounts = accounts;
 
+                let single_account = if state.accounts.len() == 1 {
+                    Some(state.accounts[0].clone())
+                } else {
+                    None
+                };
+
                 // If we have an account already selected, use that as the picklist selection
+                // or if there is only a single account to choose, use that
                 // and trigger a parse for this without user interaction
-                if let Some(account) = ajour.config.weak_auras_account.get(&flavor) {
+                if let Some(account) = ajour.config.weak_auras_account.get(&flavor).or(single_account.as_ref()) {
                     if let Some(wtf_path) = ajour.config.get_wtf_directory_for_flavor(&flavor) {
                         state.chosen_account = Some(account.clone());
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1879,12 +1879,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 // or if there is only a single account to choose, use that
                 // and trigger a parse for this without user interaction
                 let account_from_config = ajour.config.weak_auras_account.get(&flavor).cloned();
-                let get_single_account = || {
-                    if state.accounts.len() == 1 {
-                        Some(state.accounts[0].clone())
-                    } else {
-                        None
-                    }
+                let get_single_account = || match &state.accounts[..] {
+                    [a] => Some(a.clone()),
+                    _ => None,
                 };
                 if let Some(account) = account_from_config.or_else(get_single_account) {
                     if let Some(wtf_path) = ajour.config.get_wtf_directory_for_flavor(&flavor) {


### PR DESCRIPTION
Resolves #

## Proposed Changes
  - For users with only a single account, automatically pick the account when in the weak aura view

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
