### PR TITLE
remove old addon folders when updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and `Removed`.
 ### Fixed
 
 - Issue with TownlongYak addons while updating them through CLI
+- Ensure orphaned folders aren't created when updating an addon that no longer
+  has a folder from the previous version
 
 ## [0.7.1] - 2021-02-14
 

--- a/crates/core/src/fs/addon.rs
+++ b/crates/core/src/fs/addon.rs
@@ -64,6 +64,14 @@ pub async fn install_addon(
     let mut zip_file = std::fs::File::open(&zip_path)?;
     let mut archive = zip::ZipArchive::new(&mut zip_file)?;
 
+    // Remove all existing top level addon folders.
+    for folder in addon.folders.iter() {
+        let path = &folder.path;
+        if path.exists() {
+            remove_dir_all(path)?;
+        }
+    }
+
     // Get all new top level folders
     let new_top_level_folders = archive
         .file_names()


### PR DESCRIPTION
## Proposed Changes
  - When updating an addon, make sure all folders it had _before_ the update are deleted. This helps prevent orphaned folders from being created, which happens notably with addons like DBM.

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
