### PR TITLE
Fix/disable self update linux nonappimage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and `Removed`.
 ### Fixed
 
 - Issue with TownlongYak addons while updating them through CLI
+- Linux: Disable self update for non-AppImage binaries since this functionality
+  only works on the published AppImage
 
 ## [0.7.1] - 2021-02-14
 

--- a/src/gui/element/menu.rs
+++ b/src/gui/element/menu.rs
@@ -229,8 +229,16 @@ pub fn data_container<'a>(
         .width(Length::Fill)
         .style(style::NormalErrorForegroundContainer(color_palette));
 
+    #[cfg(not(target_os = "linux"))]
+    let is_updatable = true;
+
+    #[cfg(target_os = "linux")]
+    let is_updatable = std::env::var("APPIMAGE").is_ok();
+
     let version_text = Text::new(if let Some(release) = &self_update_state.latest_release {
-        if VersionCompare::compare_to(&release.tag_name, VERSION, &CompOp::Gt).unwrap_or(false) {
+        if VersionCompare::compare_to(&release.tag_name, VERSION, &CompOp::Gt).unwrap_or(false)
+            && is_updatable
+        {
             needs_update = true;
 
             format!(

--- a/src/gui/element/menu.rs
+++ b/src/gui/element/menu.rs
@@ -236,10 +236,10 @@ pub fn data_container<'a>(
     let is_updatable = std::env::var("APPIMAGE").is_ok();
 
     let version_text = Text::new(if let Some(release) = &self_update_state.latest_release {
-        if VersionCompare::compare_to(&release.tag_name, VERSION, &CompOp::Gt).unwrap_or(false)
-            && is_updatable
-        {
-            needs_update = true;
+        if VersionCompare::compare_to(&release.tag_name, VERSION, &CompOp::Gt).unwrap_or(false) {
+            if is_updatable {
+                needs_update = true;
+            }
 
             format!(
                 "{} {} -> {}",


### PR DESCRIPTION
## Proposed Changes
  - Self update for Linux only works for the published AppImage. Disable the update button for non-appimage binaries.

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
