### PR TITLE
Fix/clear error message refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and `Removed`.
 ### Changed
 
 - Better UX when opening Catalog for the first time
+- Error messages are cleared when "Refresh" is pressed
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Changed
+
+- Error messages are cleared when "Refresh" is pressed
+
 ## [0.7.2] - 2021-03-02
 
 ### Added
@@ -23,7 +27,6 @@ and `Removed`.
 ### Changed
 
 - Better UX when opening Catalog for the first time
-- Error messages are cleared when "Refresh" is pressed
 
 ### Fixed
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -132,6 +132,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::Interaction(Interaction::Refresh(mode)) => {
             log::debug!("Interaction::Refresh({})", &mode);
 
+            // Clear any error message
+            ajour.error.take();
+
             match mode {
                 Mode::MyAddons(flavor) => {
                     // Clear query


### PR DESCRIPTION
Clears any error message when user clicks Refresh. Previously you had to restart Ajour to clear out any error messages.

## Checklist

- [x] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
