### PR TITLE
fix / #579 regression

### DIFF
--- a/crates/core/src/fs/mod.rs
+++ b/crates/core/src/fs/mod.rs
@@ -3,6 +3,7 @@ use crate::error::FilesystemError;
 use once_cell::sync::Lazy;
 #[cfg(not(windows))]
 use std::env;
+use std::fs;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -45,7 +46,13 @@ pub static CONFIG_DIR: Lazy<Mutex<PathBuf>> = Lazy::new(|| {
 });
 
 pub fn config_dir() -> PathBuf {
-    CONFIG_DIR.lock().unwrap().clone()
+    let config_dir = CONFIG_DIR.lock().unwrap().clone();
+
+    if !config_dir.exists() {
+        let _ = fs::create_dir_all(&config_dir);
+    }
+
+    config_dir
 }
 
 type Result<T, E = FilesystemError> = std::result::Result<T, E>;


### PR DESCRIPTION
Fixes regression introduced from #579. All files under the data
directory implement the PersistentData trait which will make sure the
data directory exists before saving under it. However logging doesn't
follow this pattern and would try to create a file before we ensured
data directory exists.

