### PR TITLE
fix: multiple paths should be working with CLI again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fix
+
+- CLI now works properly with the new multiple path setup.
+
 ## [1.0.0] - 2021-03-23
 
 ### Added

--- a/src/command/backup.rs
+++ b/src/command/backup.rs
@@ -45,12 +45,21 @@ pub fn backup(
         let mut src_folders = vec![];
 
         for flavor in flavors {
-            let wow_dir = config.get_root_directory_for_flavor(&flavor).ok_or_else(|| format_err!("No WoW directories set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
-            let addon_directory = config.get_addon_directory_for_flavor(&flavor).ok_or_else(|| format_err!("No WoW directories set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
-            let wtf_directory = config.get_wtf_directory_for_flavor(&flavor).ok_or_else(|| format_err!("No WoW directories set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
+            let wow_directory = match config.get_root_directory_for_flavor(&flavor) {
+                Some(path) => path,
+                None => continue,
+            };
+            let addon_directory = match config.get_addon_directory_for_flavor(&flavor) {
+                Some(path) => path,
+                None => continue,
+            };
+            let wtf_directory = match config.get_wtf_directory_for_flavor(&flavor) {
+                Some(path) => path,
+                None => continue,
+            };
 
-            let addons_folder = backup::BackupFolder::new(&addon_directory, &wow_dir);
-            let wtf_folder = backup::BackupFolder::new(&wtf_directory, &wow_dir);
+            let addons_folder = backup::BackupFolder::new(&addon_directory, &wow_directory);
+            let wtf_folder = backup::BackupFolder::new(&wtf_directory, &wow_directory);
 
             match backup_folder {
                 BackupFolder::Both => {

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -45,8 +45,12 @@ pub fn install_from_source(url: Uri, flavor: Flavor) -> Result<()> {
 
         log::debug!("Installing {} for {:?}", addon.title(), flavor);
 
-        let download_directory = config.get_download_directory_for_flavor(flavor).ok_or_else(|| format_err!("No known WoW directory found for the selected flavor."))?;
-        let addon_directory = config.get_addon_directory_for_flavor(&flavor).ok_or_else(|| format_err!("No known WoW directory found for the selected flavor."))?;
+        let download_directory = config
+            .get_download_directory_for_flavor(flavor)
+            .ok_or_else(|| format_err!("No known WoW directory found for the selected flavor."))?;
+        let addon_directory = config
+            .get_addon_directory_for_flavor(&flavor)
+            .ok_or_else(|| format_err!("No known WoW directory found for the selected flavor."))?;
 
         // Download the addon
         download_addon(&addon, global_release_channel, &download_directory).await?;

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -45,8 +45,8 @@ pub fn install_from_source(url: Uri, flavor: Flavor) -> Result<()> {
 
         log::debug!("Installing {} for {:?}", addon.title(), flavor);
 
-        let download_directory = config.get_download_directory_for_flavor(flavor).ok_or_else(|| format_err!("No WoW directory set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
-        let addon_directory = config.get_addon_directory_for_flavor(&flavor).ok_or_else(|| format_err!("No WoW directory set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
+        let download_directory = config.get_download_directory_for_flavor(flavor).ok_or_else(|| format_err!("No known WoW directory found for the selected flavor."))?;
+        let addon_directory = config.get_addon_directory_for_flavor(&flavor).ok_or_else(|| format_err!("No known WoW directory found for the selected flavor."))?;
 
         // Download the addon
         download_addon(&addon, global_release_channel, &download_directory).await?;

--- a/src/command/update_addons.rs
+++ b/src/command/update_addons.rs
@@ -14,7 +14,7 @@ use ajour_core::network::download_addon;
 use ajour_core::parse::{read_addon_directory, update_addon_fingerprint};
 use ajour_core::repository::{GlobalReleaseChannel, RepositoryKind};
 
-use anyhow::{format_err, Context};
+use anyhow::Context;
 use async_std::sync::{Arc, Mutex};
 use async_std::task;
 
@@ -38,9 +38,13 @@ pub fn update_all_addons() -> Result<()> {
         let mut addons_to_update = vec![];
 
         // Update addons for both flavors
-        for flavor in Flavor::ALL.iter() {
-            // Only returns None if the path isn't set in the config
-            let addon_directory = config.get_addon_directory_for_flavor(flavor).ok_or_else(|| format_err!("No WoW directory set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
+        let flavors = config.wow.directories.keys().collect::<Vec<_>>();
+        for flavor in flavors {
+            // Returns None if no path is found
+            let addon_directory = match config.get_addon_directory_for_flavor(flavor) {
+                Some(path) => path,
+                None => continue,
+            };
 
             if let Ok(addons) = read_addon_directory(
                 Some(addon_cache.clone()),

--- a/src/command/update_addons.rs
+++ b/src/command/update_addons.rs
@@ -37,7 +37,7 @@ pub fn update_all_addons() -> Result<()> {
 
         let mut addons_to_update = vec![];
 
-        // Update addons for both flavors
+        // Update addons for known flavors
         let flavors = config.wow.directories.keys().collect::<Vec<_>>();
         for flavor in flavors {
             // Returns None if no path is found


### PR DESCRIPTION
Resolves #589 

## Proposed Changes
  - Issue is that we looped all flavors and if one failed we bailed out. I'll now loop only valid flavors (flavors added).

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
