### PR TITLE
fix: auto refresh respects excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and `Removed`.
 
 - CLI now works properly with the new multiple path setup.
 - Turkish language no longer crash Ajour in the Wago screen.
+- Auto refresh will not correctly respect the exclude list.
 
 ## [1.0.0] - 2021-03-23
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -640,6 +640,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     // we will apply that updated package to the addon, then check if
                     // the addon is updatable.
                     for addon in addons.iter_mut() {
+                        // If addon is ignored, we will skip it.
                         if ignored_ids.iter().any(|id| id == &addon.primary_folder_id) {
                             continue;
                         }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -633,12 +633,17 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     let mut has_update = 0;
 
                     let addons = ajour.addons.entry(flavor).or_default();
+                    let ignored_ids = ajour.config.addons.ignored.entry(flavor).or_default();
                     let global_release_channel = ajour.config.addons.global_release_channel;
 
                     // For each addon, check if an updated repository package exists. If it does,
                     // we will apply that updated package to the addon, then check if
                     // the addon is updatable.
                     for addon in addons.iter_mut() {
+                        if ignored_ids.iter().any(|id| id == &addon.primary_folder_id) {
+                            continue;
+                        }
+
                         if let Some(package) = packages.iter().find(|p| {
                             Some(p.id.as_str()) == addon.repository_id()
                                 && Some(p.kind) == addon.repository_kind()


### PR DESCRIPTION
resolves #596.

## Proposed Changes
  - Auto refresh did not respect excluded addons.

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
