### PR TITLE
fix: clippy warning from rust 1.51.0

### DIFF
--- a/crates/core/src/cache.rs
+++ b/crates/core/src/cache.rs
@@ -50,7 +50,7 @@ pub async fn load_fingerprint_cache() -> Result<FingerprintCache, CacheError> {
 
             rename(old_location, new_location)
                 .await
-                .map_err(FilesystemError::IO)?;
+                .map_err(FilesystemError::Io)?;
         }
     }
 

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 use std::fs::create_dir_all;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 mod addons;
 mod wow;
@@ -65,7 +65,7 @@ pub struct Config {
 
 impl Config {
     /// Returns a `PathBuf` to the flavor directory.
-    pub fn get_flavor_directory_for_flavor(&self, flavor: &Flavor, path: &PathBuf) -> PathBuf {
+    pub fn get_flavor_directory_for_flavor(&self, flavor: &Flavor, path: &Path) -> PathBuf {
         path.join(&flavor.folder_name())
     }
 

--- a/crates/core/src/config/wow.rs
+++ b/crates/core/src/config/wow.rs
@@ -31,43 +31,45 @@ impl Default for Wow {
 pub enum Flavor {
     #[serde(alias = "retail", alias = "wow_retail")]
     Retail,
-    RetailPTR,
+    #[serde(alias = "RetailPTR")]
+    RetailPtr,
     RetailBeta,
     #[serde(alias = "classic", alias = "wow_classic")]
     Classic,
-    ClassicPTR,
+    #[serde(alias = "ClassicPTR")]
+    ClassicPtr,
 }
 
 impl Flavor {
     pub const ALL: [Flavor; 5] = [
         Flavor::Retail,
-        Flavor::RetailPTR,
+        Flavor::RetailPtr,
         Flavor::RetailBeta,
         Flavor::Classic,
-        Flavor::ClassicPTR,
+        Flavor::ClassicPtr,
     ];
 
     /// Returns flavor `String` in CurseForge format
     pub(crate) fn curse_format(self) -> String {
         match self {
-            Flavor::Retail | Flavor::RetailPTR | Flavor::RetailBeta => "wow_retail".to_owned(),
-            Flavor::Classic | Flavor::ClassicPTR => "wow_classic".to_owned(),
+            Flavor::Retail | Flavor::RetailPtr | Flavor::RetailBeta => "wow_retail".to_owned(),
+            Flavor::Classic | Flavor::ClassicPtr => "wow_classic".to_owned(),
         }
     }
 
     /// Returns flavor `String` in WowUp.Hub format
     pub(crate) fn hub_format(self) -> String {
         match self {
-            Flavor::Retail | Flavor::RetailPTR | Flavor::RetailBeta => "retail".to_owned(),
-            Flavor::Classic | Flavor::ClassicPTR => "classic".to_owned(),
+            Flavor::Retail | Flavor::RetailPtr | Flavor::RetailBeta => "retail".to_owned(),
+            Flavor::Classic | Flavor::ClassicPtr => "classic".to_owned(),
         }
     }
 
     /// Returns `Flavor` which self relates to.
     pub fn base_flavor(self) -> Flavor {
         match self {
-            Flavor::Retail | Flavor::RetailPTR | Flavor::RetailBeta => Flavor::Retail,
-            Flavor::Classic | Flavor::ClassicPTR => Flavor::Classic,
+            Flavor::Retail | Flavor::RetailPtr | Flavor::RetailBeta => Flavor::Retail,
+            Flavor::Classic | Flavor::ClassicPtr => Flavor::Classic,
         }
     }
 
@@ -75,10 +77,10 @@ impl Flavor {
     pub(crate) fn folder_name(self) -> String {
         match self {
             Flavor::Retail => "_retail_".to_owned(),
-            Flavor::RetailPTR => "_ptr_".to_owned(),
+            Flavor::RetailPtr => "_ptr_".to_owned(),
             Flavor::RetailBeta => "_beta_".to_owned(),
             Flavor::Classic => "_classic_".to_owned(),
-            Flavor::ClassicPTR => "_classic_ptr_".to_owned(),
+            Flavor::ClassicPtr => "_classic_ptr_".to_owned(),
         }
     }
 }
@@ -96,10 +98,10 @@ impl std::fmt::Display for Flavor {
             "{}",
             match self {
                 Flavor::Retail => "Retail",
-                Flavor::RetailPTR => "Retail PTR",
+                Flavor::RetailPtr => "Retail PTR",
                 Flavor::RetailBeta => "Retail Beta",
                 Flavor::Classic => "Classic",
-                Flavor::ClassicPTR => "Classic PTR",
+                Flavor::ClassicPtr => "Classic PTR",
             }
         )
     }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 #[derive(thiserror::Error, Debug)]
 pub enum FilesystemError {
     #[error(transparent)]
-    IO(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
     #[error(transparent)]
     SerdeYaml(#[from] serde_yaml::Error),
     #[error(transparent)]
@@ -63,7 +63,7 @@ pub enum DownloadError {
 
 impl From<std::io::Error> for DownloadError {
     fn from(e: std::io::Error) -> Self {
-        DownloadError::Filesystem(FilesystemError::IO(e))
+        DownloadError::Filesystem(FilesystemError::Io(e))
     }
 }
 
@@ -115,7 +115,7 @@ pub enum RepositoryError {
 
 impl From<std::io::Error> for RepositoryError {
     fn from(e: std::io::Error) -> Self {
-        RepositoryError::Filesystem(FilesystemError::IO(e))
+        RepositoryError::Filesystem(FilesystemError::Io(e))
     }
 }
 
@@ -134,7 +134,7 @@ pub enum ParseError {
     #[error("No parent directory for {dir:?}")]
     NoParentDirectory { dir: PathBuf },
     #[error("Invalid UTF8 path: {path:?}")]
-    InvalidUTF8Path { path: PathBuf },
+    InvalidUtf8Path { path: PathBuf },
     #[error("Path is not a file or doesn't exist: {path:?}")]
     InvalidFile { path: PathBuf },
     #[error("Invalid extension for path: {path:?}")]
@@ -165,6 +165,6 @@ pub enum ParseError {
 
 impl From<std::io::Error> for ParseError {
     fn from(e: std::io::Error) -> Self {
-        ParseError::Filesystem(FilesystemError::IO(e))
+        ParseError::Filesystem(FilesystemError::Io(e))
     }
 }

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -829,7 +829,7 @@ pub fn fingerprint_addon_dir(addon_dir: &Path) -> Result<u32, ParseError> {
     // Add initial files
     let glob_pattern = format!(
         "{}/**/*.*",
-        addon_dir.to_str().ok_or(ParseError::InvalidUTF8Path {
+        addon_dir.to_str().ok_or(ParseError::InvalidUtf8Path {
             path: addon_dir.to_owned(),
         })?
     );
@@ -843,7 +843,7 @@ pub fn fingerprint_addon_dir(addon_dir: &Path) -> Result<u32, ParseError> {
         let relative_path = path
             .strip_prefix(root_dir)?
             .to_str()
-            .ok_or(ParseError::InvalidUTF8Path { path: path.clone() })?
+            .ok_or(ParseError::InvalidUtf8Path { path: path.clone() })?
             .to_ascii_lowercase()
             .replace("/", "\\"); // Convert to windows seperator
         if RE_PARSING_PATTERNS
@@ -873,7 +873,7 @@ pub fn fingerprint_addon_dir(addon_dir: &Path) -> Result<u32, ParseError> {
             path.extension()
                 .ok_or(ParseError::InvalidExt { path: path.clone() })?
                 .to_str()
-                .ok_or(ParseError::InvalidUTF8Path { path: path.clone() })?
+                .ok_or(ParseError::InvalidUtf8Path { path: path.clone() })?
         );
         if !RE_PARSING_PATTERNS.file_parsing_regex.contains_key(&ext) {
             continue;

--- a/crates/core/src/repository/backend/tukui.rs
+++ b/crates/core/src/repository/backend/tukui.rs
@@ -37,7 +37,7 @@ impl Backend for Tukui {
         let url = changelog_endpoint(&self.id, &self.flavor);
 
         match self.flavor {
-            Flavor::Retail | Flavor::RetailBeta | Flavor::RetailPTR => {
+            Flavor::Retail | Flavor::RetailBeta | Flavor::RetailPtr => {
                 // Only TukUI and ElvUI main addons has changelog which can be fetched.
                 // The others is embeded into a page.
                 if &self.id == "-1" || &self.id == "-2" {
@@ -56,7 +56,7 @@ impl Backend for Tukui {
                     }
                 }
             }
-            Flavor::Classic | Flavor::ClassicPTR => {}
+            Flavor::Classic | Flavor::ClassicPtr => {}
         }
 
         Ok(None)
@@ -114,7 +114,7 @@ fn format_flavor(flavor: &Flavor) -> String {
     match base_flavor {
         Flavor::Retail => "retail".to_owned(),
         Flavor::Classic => "classic".to_owned(),
-        _ => panic!(format!("Unknown base flavor {}", base_flavor)),
+        _ => panic!("Unknown base flavor {}", base_flavor),
     }
 }
 
@@ -129,12 +129,12 @@ fn api_endpoint(id: &str, flavor: &Flavor) -> String {
 
 fn changelog_endpoint(id: &str, flavor: &Flavor) -> String {
     match flavor {
-        Flavor::Retail | Flavor::RetailPTR | Flavor::RetailBeta => match id {
+        Flavor::Retail | Flavor::RetailPtr | Flavor::RetailBeta => match id {
             "-1" => "https://www.tukui.org/ui/tukui/changelog".to_owned(),
             "-2" => "https://www.tukui.org/ui/elvui/changelog".to_owned(),
             _ => format!("https://www.tukui.org/addons.php?id={}&changelog", id),
         },
-        Flavor::Classic | Flavor::ClassicPTR => format!(
+        Flavor::Classic | Flavor::ClassicPtr => format!(
             "https://www.tukui.org/classic-addons.php?id={}&changelog",
             id
         ),

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -167,8 +167,8 @@ pub async fn download_update_to_temp_file(
 /// Extracts the Ajour binary from a `tar.gz` archive to temp_file path
 #[cfg(target_os = "macos")]
 fn extract_binary_from_tar(
-    archive_path: &PathBuf,
-    temp_file: &PathBuf,
+    archive_path: &Path,
+    temp_file: &Path,
     bin_name: &str,
 ) -> Result<(), FilesystemError> {
     use flate2::read::GzDecoder;

--- a/crates/weak_auras/src/error.rs
+++ b/crates/weak_auras/src/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
     #[error("No UID for Aura {slug}")]
     MissingUid { slug: String },
     #[error(transparent)]
-    IO(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
     #[error(transparent)]
     Format(#[from] std::fmt::Error),
     #[error("{0}")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,9 +115,9 @@ fn str_to_flavor(s: &str) -> Result<Flavor, &'static str> {
     match s {
         "retail" => Ok(Flavor::Retail),
         "beta" => Ok(Flavor::RetailBeta),
-        "ptr" => Ok(Flavor::RetailPTR),
+        "ptr" => Ok(Flavor::RetailPtr),
         "classic" => Ok(Flavor::Classic),
-        "classic_ptr" => Ok(Flavor::ClassicPTR),
+        "classic_ptr" => Ok(Flavor::ClassicPtr),
         _ => Err("valid values are ['retail','ptr','beta','classic','classic_ptr']"),
     }
 }
@@ -126,13 +126,13 @@ fn str_to_flavor(s: &str) -> Result<Flavor, &'static str> {
 pub enum BackupFolder {
     Both,
     AddOns,
-    WTF,
+    Wtf,
 }
 
 fn str_to_backup_folder(s: &str) -> Result<BackupFolder, &'static str> {
     match s {
         "both" => Ok(BackupFolder::Both),
-        "wtf" => Ok(BackupFolder::WTF),
+        "wtf" => Ok(BackupFolder::Wtf),
         "addons" => Ok(BackupFolder::AddOns),
         _ => Err("valid values are ['both','wtf','addons']"),
     }

--- a/src/command/backup.rs
+++ b/src/command/backup.rs
@@ -73,7 +73,7 @@ pub fn backup(
                         src_folders.push(addons_folder);
                     }
                 }
-                BackupFolder::WTF => {
+                BackupFolder::Wtf => {
                     if wtf_directory.exists() {
                         src_folders.push(wtf_folder);
                     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -110,8 +110,8 @@ pub enum Interaction {
     MoveCatalogColumnRight(CatalogColumnKey),
     ModeSelected(Mode),
     CatalogQuery(String),
-    InstallSCMQuery(String),
-    InstallSCMURL,
+    InstallScmQuery(String),
+    InstallScmUrl,
     InstallAddon(Flavor, String, InstallKind),
     CatalogCategorySelected(CatalogCategory),
     CatalogResultSizeSelected(CatalogResultSize),
@@ -212,7 +212,7 @@ pub struct Ajour {
     website_btn_state: button::State,
     donation_btn_state: button::State,
     open_config_dir_btn_state: button::State,
-    install_from_scm_state: InstallFromSCMState,
+    install_from_scm_state: InstallFromScmState,
     self_update_channel_state: SelfUpdateChannelState,
     default_addon_release_channel_picklist_state: pick_list::State<GlobalReleaseChannel>,
     weak_auras_is_installed: bool,
@@ -669,7 +669,7 @@ impl Application for Ajour {
                 .style(style::DefaultBoxedButton(color_palette));
 
                 if matches!(install_status, None) && !installed && is_valid_url {
-                    install_button = install_button.on_press(Interaction::InstallSCMURL);
+                    install_button = install_button.on_press(Interaction::InstallScmUrl);
                 }
 
                 let install_button: Element<Interaction> = install_button.into();
@@ -678,7 +678,7 @@ impl Application for Ajour {
                     &mut self.install_from_scm_state.query_state,
                     &localized_string("install-from-url-example")[..],
                     query,
-                    Interaction::InstallSCMQuery,
+                    Interaction::InstallScmQuery,
                 )
                 .size(DEFAULT_FONT_SIZE)
                 .padding(10)
@@ -689,7 +689,7 @@ impl Application for Ajour {
                     && !matches!(install_status, Some(InstallStatus::Error(_)))
                     && is_valid_url
                 {
-                    install_scm_query = install_scm_query.on_submit(Interaction::InstallSCMURL);
+                    install_scm_query = install_scm_query.on_submit(Interaction::InstallScmUrl);
                 }
 
                 let install_scm_query: Element<Interaction> = install_scm_query.into();
@@ -1126,15 +1126,15 @@ pub fn run(opts: Opts) {
     Ajour::run(settings).expect("running Ajour gui");
 }
 
-pub struct InstallFromSCMState {
+pub struct InstallFromScmState {
     pub query: Option<String>,
     pub query_state: text_input::State,
     pub install_button_state: button::State,
 }
 
-impl Default for InstallFromSCMState {
+impl Default for InstallFromScmState {
     fn default() -> Self {
-        InstallFromSCMState {
+        InstallFromScmState {
             query: None,
             query_state: Default::default(),
             install_button_state: Default::default(),
@@ -1235,7 +1235,7 @@ impl From<&str> for ColumnKey {
             "date_released" => ColumnKey::DateReleased,
             "source" => ColumnKey::Source,
             "summary" => ColumnKey::Summary,
-            _ => panic!(format!("Unknown ColumnKey for {}", s)),
+            _ => panic!("Unknown ColumnKey for {}", s),
         }
     }
 }
@@ -1531,7 +1531,7 @@ impl From<&str> for CatalogColumnKey {
             "game_version" => CatalogColumnKey::GameVersion,
             "date_released" => CatalogColumnKey::DateReleased,
             "categories" => CatalogColumnKey::Categories,
-            _ => panic!(format!("Unknown CatalogColumnKey for {}", s)),
+            _ => panic!("Unknown CatalogColumnKey for {}", s),
         }
     }
 }
@@ -1941,6 +1941,7 @@ impl Default for ScaleState {
 #[derive(Debug, Clone)]
 pub enum BackupFolderKind {
     AddOns,
+    #[allow(clippy::upper_case_acronyms)]
     WTF,
 }
 
@@ -2045,7 +2046,7 @@ impl From<&str> for AuraColumnKey {
             "author" => AuraColumnKey::Author,
             "type" => AuraColumnKey::Type,
             "status" => AuraColumnKey::Status,
-            _ => panic!(format!("Unknown AuraColumnKey for {}", s)),
+            _ => panic!("Unknown AuraColumnKey for {}", s),
         }
     }
 }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1915,7 +1915,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
             }
         }
-        Message::Interaction(Interaction::InstallSCMQuery(query)) => {
+        Message::Interaction(Interaction::InstallScmQuery(query)) => {
             // install from scm search query
             ajour.install_from_scm_state.query = Some(query);
 
@@ -1938,7 +1938,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
             }
         }
-        Message::Interaction(Interaction::InstallSCMURL) => {
+        Message::Interaction(Interaction::InstallScmUrl) => {
             if let Some(url) = ajour.install_from_scm_state.query.clone() {
                 if !url.is_empty() {
                     return handle_message(


### PR DESCRIPTION
Resolves clippy warning from running Ajour with Rust 1.51.0

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
