### PR TITLE
fix: save single account to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and `Removed`.
 
 ### Fixed
 
-- Resolved issue where if you only have a single account, it was
-  never saved to the config.
+- Resolved issue where single accounts was never saved to the
+  config casuing the CLI `update-weakauras` not to work properly.
 
 ## [1.0.1] - 2021-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and `Removed`.
 
 ### Fixed
 
-- Resolved issue where if you only have a single account, it was never saved to the config.
+- Resolved issue where if you only have a single account, it was
+  never saved to the config.
 
 ## [1.0.1] - 2021-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolved issue where if you only have a single account, it was never saved to the config.
+
 ## [1.0.1] - 2021-03-28
 
 ### Added

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2090,7 +2090,15 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     [a] => Some(a.clone()),
                     _ => None,
                 };
+
                 if let Some(account) = account_from_config.or_else(get_single_account) {
+                    // Ensure config is updated.
+                    ajour
+                        .config
+                        .weak_auras_account
+                        .insert(flavor, account.clone());
+                    let _ = ajour.config.save();
+
                     if let Some(wtf_path) = ajour.config.get_wtf_directory_for_flavor(&flavor) {
                         state.chosen_account = Some(account.clone());
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2091,14 +2091,16 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     _ => None,
                 };
 
-                if let Some(account) = account_from_config.or_else(get_single_account) {
-                    // Ensure config is updated.
+                // If there is only a single account, we save it to the config.
+                if let Some(single_account) = get_single_account() {
                     ajour
                         .config
                         .weak_auras_account
-                        .insert(flavor, account.clone());
+                        .insert(flavor, single_account);
                     let _ = ajour.config.save();
+                }
 
+                if let Some(account) = account_from_config.or_else(get_single_account) {
                     if let Some(wtf_path) = ajour.config.get_wtf_directory_for_flavor(&flavor) {
                         state.chosen_account = Some(account.clone());
 


### PR DESCRIPTION
Resolves issue where if you only have a single account, it was never saved to the config.

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
