### PR TITLE
skip catalog addons with unknown game flavor

### DIFF
--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -117,9 +117,6 @@ pub struct CatalogAddon {
     #[serde(deserialize_with = "null_to_default::deserialize")]
     pub number_of_downloads: u64,
     pub source: Source,
-    #[serde(deserialize_with = "null_to_default::deserialize")]
-    #[deprecated(since = "0.4.4", note = "Please use game_versions instead")]
-    pub flavors: Vec<Flavor>,
     #[serde(deserialize_with = "skip_element_unknown_variant::deserialize")]
     pub game_versions: Vec<GameVersion>,
 }


### PR DESCRIPTION
Use in favor of #612

## Proposed Changes
  - Skip de serializing unknown flavors in GameVersion and filter out any catalog items that have an empty game_versions array.

## Checklist

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
