### PR TITLE
add sys tray support for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and `Removed`.
 
 ### Added
 
+- Windows: Ajour can now be closed to the system tray. New options in Settings have
+  been added to Close to the Tray, Start Ajour closed to the Tray, and Launch Ajour
+  at boot.
+  - While closed to tray, the icon can be double clicked to toggle window visibility
+    or right clicked and toggled from the menu.
 - Small labels will now indicate if there are addons or Wago's ready to be updated.
 - Added CLI command `add-path`. More information can be found in CLI.md.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.3.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1915,12 +1915,12 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.4.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 
 [[package]]
 name = "iced_futures"
 version = "0.3.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "async-std",
  "futures",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "iced_glow"
 version = "0.2.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "iced_glutin"
 version = "0.2.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "glutin",
  "iced_graphics",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.2.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "bytemuck",
  "font-kit",
@@ -1971,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "iced_native"
 version = "0.4.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.3.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "iced_core",
 ]
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "iced_web"
 version = "0.4.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "dodrio",
  "iced_core",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.4.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "bytemuck",
  "futures",
@@ -2024,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.3.0"
-source = "git+https://github.com/tarkah/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
+source = "git+https://github.com/ajour/iced?branch=revert-wgpu-0.7#fb41fd2337528ebffbd261cf257f35fa6c7e3792"
 dependencies = [
  "iced_futures",
  "iced_graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,10 @@ members = [
 ]
 
 [patch.crates-io]
-iced = { git = "https://github.com/tarkah/iced", branch = "revert-wgpu-0.7" }
-iced_native = { git = "https://github.com/tarkah/iced", branch = "revert-wgpu-0.7" }
-iced_futures = { git = "https://github.com/tarkah/iced", branch = "revert-wgpu-0.7" }
-iced_graphics = { git = "https://github.com/tarkah/iced", branch = "revert-wgpu-0.7" }
-iced_core = { git = "https://github.com/tarkah/iced", branch = "revert-wgpu-0.7" }
-iced_wgpu = { git = "https://github.com/tarkah/iced", branch = "revert-wgpu-0.7" }
-iced_glow = { git = "https://github.com/tarkah/iced", branch = "revert-wgpu-0.7" }
+iced = { git = "https://github.com/ajour/iced", branch = "revert-wgpu-0.7" }
+iced_native = { git = "https://github.com/ajour/iced", branch = "revert-wgpu-0.7" }
+iced_futures = { git = "https://github.com/ajour/iced", branch = "revert-wgpu-0.7" }
+iced_graphics = { git = "https://github.com/ajour/iced", branch = "revert-wgpu-0.7" }
+iced_core = { git = "https://github.com/ajour/iced", branch = "revert-wgpu-0.7" }
+iced_wgpu = { git = "https://github.com/ajour/iced", branch = "revert-wgpu-0.7" }
+iced_glow = { git = "https://github.com/ajour/iced", branch = "revert-wgpu-0.7" }

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -73,6 +73,10 @@ pub struct Config {
     #[serde(default)]
     #[cfg(target_os = "windows")]
     pub autostart: bool,
+
+    #[serde(default)]
+    #[cfg(target_os = "windows")]
+    pub start_closed_to_tray: bool,
 }
 
 impl Config {

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -67,7 +67,12 @@ pub struct Config {
     pub compression_format: CompressionFormat,
 
     #[serde(default)]
+    #[cfg(target_os = "windows")]
     pub close_to_tray: bool,
+
+    #[serde(default)]
+    #[cfg(target_os = "windows")]
+    pub autostart: bool,
 }
 
 impl Config {

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -65,6 +65,9 @@ pub struct Config {
 
     #[serde(default)]
     pub compression_format: CompressionFormat,
+
+    #[serde(default)]
+    pub close_to_tray: bool,
 }
 
 impl Config {

--- a/locale/en.json
+++ b/locale/en.json
@@ -119,5 +119,6 @@
     "type": "Type",
     "wow-directories": "World of Warcraft directories",
     "donate": "Donate",
-    "donate-http": "https://www.getajour.com/donate"
+    "donate-http": "https://www.getajour.com/donate",
+    "close-to-tray": "Close to System Tray"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -121,5 +121,6 @@
     "donate": "Donate",
     "donate-http": "https://www.getajour.com/donate",
     "close-to-tray": "Close to System Tray",
-    "toggle-autostart": "Launch Ajour at boot"
+    "toggle-autostart": "Launch Ajour at boot",
+    "start-closed-to-tray": "Start Ajour closed to Tray"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -120,5 +120,6 @@
     "wow-directories": "World of Warcraft directories",
     "donate": "Donate",
     "donate-http": "https://www.getajour.com/donate",
-    "close-to-tray": "Close to System Tray"
+    "close-to-tray": "Close to System Tray",
+    "toggle-autostart": "Launch Ajour at boot"
 }

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -598,7 +598,9 @@ pub fn data_container<'a, 'b>(
         .push(Space::new(Length::Units(0), Length::Units(10)))
         .push(self_update_channel_container)
         .push(Space::new(Length::Units(0), Length::Units(10)))
-        .push(config_column);
+        .push(config_column)
+        .push(Space::new(Length::Units(0), Length::Units(10)))
+        .push(auto_update_column);
 
     #[cfg(target_os = "windows")]
     {
@@ -637,9 +639,7 @@ pub fn data_container<'a, 'b>(
         .push(Space::new(Length::Units(0), Length::Units(10)))
         .push(hide_addons_column)
         .push(Space::new(Length::Units(0), Length::Units(10)))
-        .push(delete_saved_variables_column)
-        .push(Space::new(Length::Units(0), Length::Units(10)))
-        .push(auto_update_column);
+        .push(delete_saved_variables_column);
 
     let columns_title_text = Text::new(localized_string("columns")).size(DEFAULT_HEADER_FONT_SIZE);
     let columns_title_text_container =

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -536,6 +536,24 @@ pub fn data_container<'a, 'b>(
         Column::new().push(checkbox_container)
     };
 
+    #[cfg(target_os = "windows")]
+    let toggle_autostart_column = {
+        let checkbox = Checkbox::new(
+            config.autostart,
+            localized_string("toggle-autostart"),
+            Interaction::ToggleAutoStart,
+        )
+        .style(style::DefaultCheckbox(color_palette))
+        .text_size(DEFAULT_FONT_SIZE)
+        .spacing(5);
+
+        let checkbox: Element<Interaction> = checkbox.into();
+
+        let checkbox_container = Container::new(checkbox.map(Message::Interaction))
+            .style(style::NormalBackgroundContainer(color_palette));
+        Column::new().push(checkbox_container)
+    };
+
     // General
     scrollable = scrollable
         .push(general_settings_title_container)
@@ -555,6 +573,8 @@ pub fn data_container<'a, 'b>(
         scrollable = scrollable
             .push(Space::new(Length::Units(0), Length::Units(10)))
             .push(close_to_tray_column)
+            .push(Space::new(Length::Units(0), Length::Units(10)))
+            .push(toggle_autostart_column);
     }
 
     scrollable = scrollable.push(Space::new(Length::Units(0), Length::Units(30)));

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -554,6 +554,38 @@ pub fn data_container<'a, 'b>(
         Column::new().push(checkbox_container)
     };
 
+    #[cfg(target_os = "windows")]
+    let start_closed_to_tray_column = {
+        let callback = if config.close_to_tray {
+            |enable| Message::Interaction(Interaction::ToggleStartClosedToTray(enable))
+        } else {
+            |_| Message::None(())
+        };
+
+        let mut checkbox = Checkbox::new(
+            if config.close_to_tray {
+                config.start_closed_to_tray
+            } else {
+                false
+            },
+            localized_string("start-closed-to-tray"),
+            callback,
+        )
+        .text_size(DEFAULT_FONT_SIZE)
+        .spacing(5);
+
+        if config.close_to_tray {
+            checkbox = checkbox.style(style::DefaultCheckbox(color_palette));
+        } else {
+            // Not checked, but looks "disabled"
+            checkbox = checkbox.style(style::AlwaysCheckedCheckbox(color_palette));
+        }
+
+        let checkbox_container =
+            Container::new(checkbox).style(style::NormalBackgroundContainer(color_palette));
+        Column::new().push(checkbox_container)
+    };
+
     // General
     scrollable = scrollable
         .push(general_settings_title_container)
@@ -573,6 +605,8 @@ pub fn data_container<'a, 'b>(
         scrollable = scrollable
             .push(Space::new(Length::Units(0), Length::Units(10)))
             .push(close_to_tray_column)
+            .push(Space::new(Length::Units(0), Length::Units(10)))
+            .push(start_closed_to_tray_column)
             .push(Space::new(Length::Units(0), Length::Units(10)))
             .push(toggle_autostart_column);
     }

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -556,33 +556,19 @@ pub fn data_container<'a, 'b>(
 
     #[cfg(target_os = "windows")]
     let start_closed_to_tray_column = {
-        let callback = if config.close_to_tray {
-            |enable| Message::Interaction(Interaction::ToggleStartClosedToTray(enable))
-        } else {
-            |_| Message::None(())
-        };
-
-        let mut checkbox = Checkbox::new(
-            if config.close_to_tray {
-                config.start_closed_to_tray
-            } else {
-                false
-            },
+        let checkbox = Checkbox::new(
+            config.start_closed_to_tray,
             localized_string("start-closed-to-tray"),
-            callback,
+            Interaction::ToggleStartClosedToTray,
         )
+        .style(style::DefaultCheckbox(color_palette))
         .text_size(DEFAULT_FONT_SIZE)
         .spacing(5);
 
-        if config.close_to_tray {
-            checkbox = checkbox.style(style::DefaultCheckbox(color_palette));
-        } else {
-            // Not checked, but looks "disabled"
-            checkbox = checkbox.style(style::AlwaysCheckedCheckbox(color_palette));
-        }
+        let checkbox: Element<Interaction> = checkbox.into();
 
-        let checkbox_container =
-            Container::new(checkbox).style(style::NormalBackgroundContainer(color_palette));
+        let checkbox_container = Container::new(checkbox.map(Message::Interaction))
+            .style(style::NormalBackgroundContainer(color_palette));
         Column::new().push(checkbox_container)
     };
 

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -518,6 +518,24 @@ pub fn data_container<'a, 'b>(
             .push(container)
     };
 
+    #[cfg(target_os = "windows")]
+    let close_to_tray_column = {
+        let checkbox = Checkbox::new(
+            config.close_to_tray,
+            localized_string("close-to-tray"),
+            Interaction::ToggleCloseToTray,
+        )
+        .style(style::DefaultCheckbox(color_palette))
+        .text_size(DEFAULT_FONT_SIZE)
+        .spacing(5);
+
+        let checkbox: Element<Interaction> = checkbox.into();
+
+        let checkbox_container = Container::new(checkbox.map(Message::Interaction))
+            .style(style::NormalBackgroundContainer(color_palette));
+        Column::new().push(checkbox_container)
+    };
+
     // General
     scrollable = scrollable
         .push(general_settings_title_container)
@@ -530,8 +548,16 @@ pub fn data_container<'a, 'b>(
         .push(Space::new(Length::Units(0), Length::Units(10)))
         .push(self_update_channel_container)
         .push(Space::new(Length::Units(0), Length::Units(10)))
-        .push(config_column)
-        .push(Space::new(Length::Units(0), Length::Units(30)));
+        .push(config_column);
+
+    #[cfg(target_os = "windows")]
+    {
+        scrollable = scrollable
+            .push(Space::new(Length::Units(0), Length::Units(10)))
+            .push(close_to_tray_column)
+    }
+
+    scrollable = scrollable.push(Space::new(Length::Units(0), Length::Units(30)));
 
     // Directories
     scrollable = scrollable

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -133,6 +133,8 @@ pub enum Interaction {
     ToggleCloseToTray(bool),
     #[cfg(target_os = "windows")]
     ToggleAutoStart(bool),
+    #[cfg(target_os = "windows")]
+    ToggleStartClosedToTray(bool),
 }
 
 #[derive(Debug)]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -131,6 +131,8 @@ pub enum Interaction {
     ToggleAutoUpdateAddons(bool),
     #[cfg(target_os = "windows")]
     ToggleCloseToTray(bool),
+    #[cfg(target_os = "windows")]
+    ToggleAutoStart(bool),
 }
 
 #[derive(Debug)]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -129,6 +129,8 @@ pub enum Interaction {
     ToggleDeleteSavedVariables(bool),
     AddonsQuery(String),
     ToggleAutoUpdateAddons(bool),
+    #[cfg(target_os = "windows")]
+    ToggleCloseToTray(bool),
 }
 
 #[derive(Debug)]
@@ -322,6 +324,14 @@ impl Application for Ajour {
 
     fn scale_factor(&self) -> f64 {
         self.scale_state.scale
+    }
+
+    #[cfg(target_os = "windows")]
+    fn should_exit(&self) -> bool {
+        use crate::tray::SHOULD_EXIT;
+        use std::sync::atomic::Ordering;
+
+        SHOULD_EXIT.load(Ordering::Relaxed)
     }
 
     fn subscription(&self) -> Subscription<Self::Message> {
@@ -1095,9 +1105,7 @@ impl Application for Ajour {
 
 /// Starts the GUI.
 /// This function does not return.
-pub fn run(opts: Opts) {
-    let config: Config = Config::load_or_default().expect("loading config on application startup");
-
+pub fn run(opts: Opts, config: Config) {
     // Set LANG using config (defaults to "en_US")
     LANG.set(RwLock::new(config.language.language_code()))
         .expect("setting LANG from config");
@@ -1106,6 +1114,11 @@ pub fn run(opts: Opts) {
 
     let mut settings = Settings::default();
     settings.window.size = config.window_size.unwrap_or((900, 620));
+
+    #[cfg(target_os = "windows")]
+    {
+        settings.exit_on_close_request = false;
+    }
 
     #[cfg(not(target_os = "linux"))]
     // TODO (casperstorm): Due to an upstream bug, min_size causes the window to become unresizable

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2285,6 +2285,19 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 let _ = sender.try_send(msg);
             }
         }
+        #[cfg(target_os = "windows")]
+        Message::Interaction(Interaction::ToggleAutoStart(enable)) => {
+            log::debug!("Interaction::ToggleAutoStart({})", enable);
+
+            use crate::tray::{TrayMessage, TRAY_SENDER};
+
+            ajour.config.autostart = enable;
+            let _ = ajour.config.save();
+
+            if let Some(sender) = TRAY_SENDER.get() {
+                let _ = sender.try_send(TrayMessage::ToggleAutoStart(enable));
+            }
+        }
         Message::RuntimeEvent(_) => {}
         Message::None(_) => {}
     }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2277,14 +2277,6 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             // Remove start closed to tray if we are disabling
             if !enable {
                 ajour.config.start_closed_to_tray = false;
-            } else {
-            }
-
-            // If autostart is enabled and user enables tray,
-            // sane default is to have it close to try. This can be disabled
-            // manually by user
-            if enable && ajour.config.autostart {
-                ajour.config.start_closed_to_tray = true;
             }
 
             let _ = ajour.config.save();
@@ -2305,13 +2297,6 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             ajour.config.autostart = enable;
 
-            // If tray is enabled and user wants to autostart Ajour,
-            // sane default is to have it close to try. This can be disabled
-            // manually by user
-            if enable && ajour.config.close_to_tray {
-                ajour.config.start_closed_to_tray = true;
-            }
-
             let _ = ajour.config.save();
 
             if let Some(sender) = TRAY_SENDER.get() {
@@ -2323,6 +2308,16 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             log::debug!("Interaction::ToggleStartClosedToTray({})", enable);
 
             ajour.config.start_closed_to_tray = enable;
+
+            // Enable tray if this feature is enabled
+            if enable && !ajour.config.close_to_tray {
+                ajour.config.close_to_tray = true;
+
+                if let Some(sender) = TRAY_SENDER.get() {
+                    let _ = sender.try_send(TrayMessage::Enable);
+                }
+            }
+
             let _ = ajour.config.save();
         }
         Message::RuntimeEvent(_) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ pub fn main() {
                 Config::load_or_default().expect("loading config on application startup");
 
             #[cfg(target_os = "windows")]
-            tray::spawn_sys_tray(config.close_to_tray);
+            tray::spawn_sys_tray(config.close_to_tray, config.start_closed_to_tray);
 
             // Start the GUI
             gui::run(opts, config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,11 @@ mod cli;
 mod command;
 mod gui;
 mod localization;
+#[cfg(target_os = "windows")]
+mod tray;
 
-use ajour_core::fs::CONFIG_DIR;
+use ajour_core::config::Config;
+use ajour_core::fs::{PersistentData, CONFIG_DIR};
 use ajour_core::utility::{remove_file, rename};
 
 #[cfg(target_os = "linux")]
@@ -87,8 +90,14 @@ pub fn main() {
             }
         }
         None => {
+            let config: Config =
+                Config::load_or_default().expect("loading config on application startup");
+
+            #[cfg(target_os = "windows")]
+            tray::spawn_sys_tray(config.close_to_tray);
+
             // Start the GUI
-            gui::run(opts);
+            gui::run(opts, config);
         }
     }
 }

--- a/src/tray/autostart.rs
+++ b/src/tray/autostart.rs
@@ -1,0 +1,61 @@
+use std::env;
+use std::fs;
+use std::mem;
+use std::ptr;
+
+use ajour_core::fs::CONFIG_DIR;
+use anyhow::Error;
+use winapi::shared::minwindef::HKEY;
+use winapi::um::winnt::{KEY_SET_VALUE, REG_OPTION_NON_VOLATILE, REG_SZ};
+use winapi::um::winreg::{RegCreateKeyExW, RegDeleteKeyValueW, RegSetValueExW, HKEY_CURRENT_USER};
+
+use crate::str_to_wide;
+
+pub unsafe fn toggle_autostart(enabled: bool) -> Result<(), Error> {
+    let mut app_path = CONFIG_DIR.lock().unwrap().to_owned();
+    app_path.push("ajour.exe");
+
+    // Copy Ajour to config directory so we can autostart it from there
+    let current_path = env::current_exe()?;
+    if current_path != app_path && enabled {
+        fs::copy(current_path, &app_path)?;
+    }
+
+    let app_path = str_to_wide!(app_path.to_str().unwrap_or_default());
+    let mut key_name = str_to_wide!("Software\\Microsoft\\Windows\\CurrentVersion\\Run");
+    let mut value_name = str_to_wide!("ajour");
+
+    let mut key: HKEY = mem::zeroed();
+
+    if enabled {
+        if RegCreateKeyExW(
+            HKEY_CURRENT_USER,
+            key_name.as_mut_ptr(),
+            0,
+            ptr::null_mut(),
+            REG_OPTION_NON_VOLATILE,
+            KEY_SET_VALUE,
+            ptr::null_mut(),
+            &mut key,
+            ptr::null_mut(),
+        ) == 0
+        {
+            RegSetValueExW(
+                key,
+                value_name.as_mut_ptr(),
+                0,
+                REG_SZ,
+                app_path.as_ptr() as _,
+                app_path.len() as u32 * 2,
+            );
+        }
+    } else {
+        RegDeleteKeyValueW(
+            HKEY_CURRENT_USER,
+            key_name.as_mut_ptr(),
+            value_name.as_mut_ptr(),
+        );
+    }
+
+    Ok(())
+}

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -20,9 +20,9 @@ use winapi::um::winuser::{
     RegisterClassExW, SendMessageW, SetFocus, SetForegroundWindow, SetMenuDefaultItem,
     SetWindowLongPtrW, ShowWindow, TrackPopupMenu, TranslateMessage, CREATESTRUCTW, GWLP_USERDATA,
     MAKEINTRESOURCEW, MB_ICONINFORMATION, MB_OK, MF_BYPOSITION, MF_GRAYED, MF_SEPARATOR, MF_STRING,
-    SW_HIDE, SW_RESTORE, SW_SHOWMINIMIZED, TPM_LEFTALIGN, TPM_NONOTIFY, TPM_RETURNCMD,
-    TPM_RIGHTBUTTON, WM_APP, WM_CLOSE, WM_COMMAND, WM_CREATE, WM_DESTROY, WM_INITMENUPOPUP,
-    WM_LBUTTONDBLCLK, WM_RBUTTONUP, WNDCLASSEXW, WS_EX_NOACTIVATE,
+    SW_HIDE, SW_RESTORE, TPM_LEFTALIGN, TPM_NONOTIFY, TPM_RETURNCMD, TPM_RIGHTBUTTON, WM_APP,
+    WM_CLOSE, WM_COMMAND, WM_CREATE, WM_DESTROY, WM_INITMENUPOPUP, WM_LBUTTONDBLCLK, WM_RBUTTONUP,
+    WNDCLASSEXW, WS_EX_NOACTIVATE,
 };
 
 use crate::log_error;
@@ -189,7 +189,7 @@ unsafe fn create_window(show_balloon: bool) {
             SHOULD_EXIT.store(true, Ordering::Relaxed);
 
             // Activate window to force event loop to run / see that it should now close
-            ShowWindow(tray_state.gui_handle.unwrap(), SW_SHOWMINIMIZED);
+            SetForegroundWindow(tray_state.gui_handle.unwrap());
         }
     });
 }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -19,10 +19,10 @@ use winapi::um::winuser::{
     GetWindowThreadProcessId, InsertMenuW, LoadIconW, MessageBoxW, PostMessageW, PostQuitMessage,
     RegisterClassExW, SendMessageW, SetFocus, SetForegroundWindow, SetMenuDefaultItem,
     SetWindowLongPtrW, ShowWindow, TrackPopupMenu, TranslateMessage, CREATESTRUCTW, GWLP_USERDATA,
-    MAKEINTRESOURCEW, MB_ICONINFORMATION, MB_OK, MF_BYPOSITION, MF_STRING, SW_HIDE, SW_RESTORE,
-    SW_SHOWMINIMIZED, TPM_LEFTALIGN, TPM_NONOTIFY, TPM_RETURNCMD, TPM_RIGHTBUTTON, WINDOWINFO,
-    WM_APP, WM_CLOSE, WM_COMMAND, WM_CREATE, WM_DESTROY, WM_INITMENUPOPUP, WM_LBUTTONDBLCLK,
-    WM_RBUTTONUP, WNDCLASSEXW, WS_EX_NOACTIVATE,
+    MAKEINTRESOURCEW, MB_ICONINFORMATION, MB_OK, MF_BYPOSITION, MF_GRAYED, MF_SEPARATOR, MF_STRING,
+    SW_HIDE, SW_RESTORE, SW_SHOWMINIMIZED, TPM_LEFTALIGN, TPM_NONOTIFY, TPM_RETURNCMD,
+    TPM_RIGHTBUTTON, WINDOWINFO, WM_APP, WM_CLOSE, WM_COMMAND, WM_CREATE, WM_DESTROY,
+    WM_INITMENUPOPUP, WM_LBUTTONDBLCLK, WM_RBUTTONUP, WNDCLASSEXW, WS_EX_NOACTIVATE,
 };
 
 pub static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
@@ -224,21 +224,13 @@ unsafe fn show_popup_menu(hwnd: HWND, state: &TrayState) {
 
     let hidden = state.gui_hidden;
 
-    let mut about = str_to_wide!("About...");
-    let mut toggle = str_to_wide!(if hidden { "Show window" } else { "Hide window" });
+    let mut about = str_to_wide!("About");
+    let mut toggle = str_to_wide!(if hidden { "Open Ajour" } else { "Hide Ajour" });
     let mut exit = str_to_wide!("Exit");
 
     InsertMenuW(
         menu,
         0,
-        MF_BYPOSITION | MF_STRING,
-        ID_ABOUT as usize,
-        about.as_mut_ptr(),
-    );
-
-    InsertMenuW(
-        menu,
-        1,
         MF_BYPOSITION | MF_STRING,
         ID_TOGGLE_WINDOW as usize,
         toggle.as_mut_ptr(),
@@ -246,13 +238,23 @@ unsafe fn show_popup_menu(hwnd: HWND, state: &TrayState) {
 
     InsertMenuW(
         menu,
-        2,
+        1,
+        MF_BYPOSITION | MF_STRING,
+        ID_ABOUT as usize,
+        about.as_mut_ptr(),
+    );
+
+    InsertMenuW(menu, 2, MF_SEPARATOR | MF_GRAYED, 0, ptr::null_mut());
+
+    InsertMenuW(
+        menu,
+        3,
         MF_BYPOSITION | MF_STRING,
         ID_EXIT as usize,
         exit.as_mut_ptr(),
     );
 
-    SetMenuDefaultItem(menu, ID_ABOUT as u32, 0);
+    SetMenuDefaultItem(menu, ID_TOGGLE_WINDOW as u32, 0);
     SetFocus(hwnd);
     SendMessageW(hwnd, WM_INITMENUPOPUP, menu as usize, 0);
 

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -2,15 +2,15 @@ use std::mem;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, SyncSender};
-use std::sync::{Arc, Mutex};
-use std::thread::{self, JoinHandle};
+use std::thread::{self};
 
 use once_cell::sync::OnceCell;
 use winapi::shared::minwindef::{BOOL, LOWORD, LPARAM, LRESULT, UINT, WPARAM};
 use winapi::shared::windef::{HWND, POINT};
 use winapi::um::libloaderapi::GetModuleHandleW;
 use winapi::um::shellapi::{
-    Shell_NotifyIconW, NIF_ICON, NIF_MESSAGE, NIF_TIP, NIM_ADD, NIM_DELETE, NOTIFYICONDATAW,
+    Shell_NotifyIconW, NIF_ICON, NIF_INFO, NIF_MESSAGE, NIF_TIP, NIIF_NONE, NIIF_NOSOUND, NIM_ADD,
+    NIM_DELETE, NIM_MODIFY, NOTIFYICONDATAW,
 };
 use winapi::um::wingdi::{CreateSolidBrush, RGB};
 use winapi::um::winuser::{
@@ -19,7 +19,7 @@ use winapi::um::winuser::{
     GetWindowThreadProcessId, InsertMenuW, LoadIconW, MessageBoxW, PostMessageW, PostQuitMessage,
     RegisterClassExW, SendMessageW, SetFocus, SetForegroundWindow, SetMenuDefaultItem,
     SetWindowLongPtrW, ShowWindow, TrackPopupMenu, TranslateMessage, CREATESTRUCTW, GWLP_USERDATA,
-    MAKEINTRESOURCEW, MB_ICONINFORMATION, MB_OK, MF_BYPOSITION, MF_STRING, SW_HIDE, SW_SHOW,
+    MAKEINTRESOURCEW, MB_ICONINFORMATION, MB_OK, MF_BYPOSITION, MF_STRING, SW_HIDE, SW_RESTORE,
     SW_SHOWMINIMIZED, TPM_LEFTALIGN, TPM_NONOTIFY, TPM_RETURNCMD, TPM_RIGHTBUTTON, WINDOWINFO,
     WM_APP, WM_CLOSE, WM_COMMAND, WM_CREATE, WM_DESTROY, WM_INITMENUPOPUP, WM_LBUTTONDBLCLK,
     WM_RBUTTONUP, WNDCLASSEXW, WS_EX_NOACTIVATE,
@@ -31,18 +31,19 @@ pub static TRAY_SENDER: OnceCell<SyncSender<TrayMessage>> = OnceCell::new();
 const ID_ABOUT: u16 = 2000;
 const ID_TOGGLE_WINDOW: u16 = 2001;
 const ID_EXIT: u16 = 2002;
+const WM_HIDE_GUI: u32 = WM_APP + 1;
 
-#[derive(Debug, Clone, Copy)]
 pub enum TrayMessage {
     Enable,
     Disable,
     CloseToTray,
+    TrayCreated(WindowHandle),
 }
 
 #[derive(Debug)]
 struct TrayState {
     gui_handle: Option<HWND>,
-    hidden: bool,
+    gui_hidden: bool,
     about_shown: bool,
     close_gui: bool,
 }
@@ -50,10 +51,10 @@ struct TrayState {
 unsafe impl Send for TrayState {}
 unsafe impl Sync for TrayState {}
 
-struct Window(HWND);
+pub struct WindowHandle(HWND);
 
-unsafe impl Send for Window {}
-unsafe impl Sync for Window {}
+unsafe impl Send for WindowHandle {}
+unsafe impl Sync for WindowHandle {}
 
 macro_rules! str_to_wide {
     ($str:expr) => {{
@@ -68,51 +69,51 @@ pub fn spawn_sys_tray(enabled: bool) {
         let (sender, receiver) = sync_channel(1);
         let _ = TRAY_SENDER.set(sender);
 
-        let window: Arc<Mutex<Option<Window>>> = Default::default();
+        // Stores the window handle so we can post messages to its queue
+        let mut window: Option<WindowHandle> = None;
 
         // Spawn tray initially if enabled
         if enabled {
-            unsafe { spawn(window.clone()) };
+            unsafe { create_window() };
         }
 
         while let Ok(msg) = receiver.recv() {
             match msg {
-                TrayMessage::Enable => {
-                    if window.lock().unwrap().is_none() {
-                        unsafe { spawn(window.clone()) };
-                    }
-                }
-                TrayMessage::Disable => {
-                    if let Some(window) = window.lock().unwrap().take() {
-                        unsafe { PostMessageW(window.0, WM_CLOSE, 1, 0) };
-                    }
-                }
-                TrayMessage::CloseToTray => unsafe {
-                    if let Some(window) = window.lock().unwrap().as_ref() {
-                        let ptr = GetWindowLongPtrW(window.0, GWLP_USERDATA);
-                        let state = &mut *(ptr as *mut TrayState);
-
-                        state.hidden = true;
-                        ShowWindow(*state.gui_handle.as_ref().unwrap(), SW_HIDE);
+                TrayMessage::Enable => unsafe {
+                    if window.is_none() {
+                        create_window();
                     }
                 },
+                TrayMessage::Disable => unsafe {
+                    if let Some(window) = window.take() {
+                        PostMessageW(window.0, WM_CLOSE, 1, 0);
+                    }
+                },
+                TrayMessage::CloseToTray => unsafe {
+                    if let Some(window) = window.as_ref() {
+                        PostMessageW(window.0, WM_HIDE_GUI, 0, 0);
+                    }
+                },
+                TrayMessage::TrayCreated(win) => {
+                    window = Some(win);
+                }
             }
         }
     });
 }
 
-unsafe fn spawn(window: Arc<Mutex<Option<Window>>>) -> JoinHandle<()> {
+unsafe fn create_window() {
     thread::spawn(move || {
         let mut tray_state = TrayState {
             gui_handle: None,
-            hidden: false,
+            gui_hidden: false,
             about_shown: false,
             close_gui: false,
         };
 
         // Keep searching for window handle until its found
         while tray_state.gui_handle.is_none() {
-            EnumWindows(Some(wndenumproc), &mut tray_state as *mut _ as LPARAM);
+            EnumWindows(Some(enum_proc), &mut tray_state as *mut _ as LPARAM);
         }
 
         let h_instance = GetModuleHandleW(ptr::null());
@@ -121,7 +122,7 @@ unsafe fn spawn(window: Arc<Mutex<Option<Window>>>) -> JoinHandle<()> {
 
         let mut class = mem::zeroed::<WNDCLASSEXW>();
         class.cbSize = mem::size_of::<WNDCLASSEXW>() as u32;
-        class.lpfnWndProc = Some(callback);
+        class.lpfnWndProc = Some(window_proc);
         class.hInstance = h_instance;
         class.lpszClassName = class_name.as_ptr();
         class.hbrBackground = CreateSolidBrush(RGB(0, 77, 128));
@@ -143,7 +144,11 @@ unsafe fn spawn(window: Arc<Mutex<Option<Window>>>) -> JoinHandle<()> {
             &mut tray_state as *mut _ as *mut std::ffi::c_void,
         );
 
-        *window.lock().unwrap() = Some(Window(hwnd));
+        // Send window handle back to main loop so we can post messages to it
+        let _ = TRAY_SENDER
+            .get()
+            .unwrap()
+            .try_send(TrayMessage::TrayCreated(WindowHandle(hwnd)));
 
         let mut msg = mem::zeroed();
         while GetMessageW(&mut msg, ptr::null_mut(), 0, 0) != 0 {
@@ -158,7 +163,7 @@ unsafe fn spawn(window: Arc<Mutex<Option<Window>>>) -> JoinHandle<()> {
             // Activate window to force event loop to run / see that it should now close
             ShowWindow(tray_state.gui_handle.unwrap(), SW_SHOWMINIMIZED);
         }
-    })
+    });
 }
 
 unsafe fn add_icon(hwnd: HWND) {
@@ -184,8 +189,31 @@ unsafe fn add_icon(hwnd: HWND) {
     Shell_NotifyIconW(NIM_ADD, &mut icon_data);
 }
 
+unsafe fn display_balloon_message(hwnd: HWND, message: &str) {
+    let mut info = [0u16; 256];
+    let message = str_to_wide!(message);
+
+    for (idx, b) in message[0..message.len().min(255)].iter().enumerate() {
+        info[idx] = *b;
+    }
+
+    let mut icon_data: NOTIFYICONDATAW = mem::zeroed();
+    icon_data.cbSize = mem::size_of::<NOTIFYICONDATAW>() as u32;
+    icon_data.hWnd = hwnd;
+    icon_data.uID = 1;
+    //icon_data.uCallbackMessage = WM_APP;
+    icon_data.uFlags = NIF_INFO; // NIF_ICON | NIF_MESSAGE | NIF_TIP;
+                                 //icon_data.hIcon = icon_handle;
+                                 //icon_data.szTip = tooltip_array;
+    icon_data.szInfo = info;
+    icon_data.dwInfoFlags = NIIF_NONE | NIIF_NOSOUND;
+
+    Shell_NotifyIconW(NIM_MODIFY, &mut icon_data);
+}
+
 unsafe fn remove_icon(hwnd: HWND) {
     let mut icon_data: NOTIFYICONDATAW = mem::zeroed();
+    icon_data.cbSize = mem::size_of::<NOTIFYICONDATAW>() as u32;
     icon_data.hWnd = hwnd;
     icon_data.uID = 1;
 
@@ -195,7 +223,7 @@ unsafe fn remove_icon(hwnd: HWND) {
 unsafe fn show_popup_menu(hwnd: HWND, state: &TrayState) {
     let menu = CreatePopupMenu();
 
-    let hidden = state.hidden;
+    let hidden = state.gui_hidden;
 
     let mut about = str_to_wide!("About...");
     let mut toggle = str_to_wide!(if hidden { "Show window" } else { "Hide window" });
@@ -265,7 +293,7 @@ unsafe fn show_about() {
     );
 }
 
-unsafe extern "system" fn callback(
+unsafe extern "system" fn window_proc(
     hwnd: HWND,
     msg: UINT,
     wparam: WPARAM,
@@ -279,6 +307,8 @@ unsafe extern "system" fn callback(
         SetWindowLongPtrW(hwnd, GWLP_USERDATA, state as *mut _ as LPARAM);
 
         add_icon(hwnd);
+
+        display_balloon_message(hwnd, "Running from Tray...");
 
         return 0;
     } else {
@@ -306,47 +336,62 @@ unsafe extern "system" fn callback(
             match LOWORD(wparam as u32) {
                 ID_ABOUT => {
                     // Don't show if already up
-                    if state.about_shown {
-                        return 1;
+                    if !state.about_shown {
+                        state.about_shown = true;
+
+                        show_about();
+
+                        state.about_shown = false;
+
+                        return 0;
                     }
-
-                    state.about_shown = true;
-
-                    show_about();
-
-                    state.about_shown = false;
                 }
                 ID_TOGGLE_WINDOW => {
-                    let cmd = if state.hidden { SW_SHOW } else { SW_HIDE };
+                    let cmd = if state.gui_hidden {
+                        SW_RESTORE
+                    } else {
+                        SW_HIDE
+                    };
 
                     ShowWindow(*state.gui_handle.as_ref().unwrap(), cmd);
 
-                    state.hidden = !state.hidden;
+                    state.gui_hidden = !state.gui_hidden;
+
+                    return 0;
                 }
                 ID_EXIT => {
                     PostMessageW(hwnd, WM_CLOSE, 0, 0);
+                    return 0;
                 }
                 _ => {}
             }
-
-            return 0;
         }
-        WM_APP => {
-            match lparam as u32 {
-                WM_LBUTTONDBLCLK => {
-                    let cmd = if state.hidden { SW_SHOW } else { SW_HIDE };
+        WM_APP => match lparam as u32 {
+            WM_LBUTTONDBLCLK => {
+                let cmd = if state.gui_hidden {
+                    SW_RESTORE
+                } else {
+                    SW_HIDE
+                };
 
-                    ShowWindow(*state.gui_handle.as_ref().unwrap(), cmd);
+                ShowWindow(*state.gui_handle.as_ref().unwrap(), cmd);
 
-                    state.hidden = !state.hidden;
-                }
-                WM_RBUTTONUP => {
-                    SetForegroundWindow(hwnd);
-                    show_popup_menu(hwnd, state);
-                    PostMessageW(hwnd, WM_APP + 1, 0, 0);
-                }
-                _ => {}
+                state.gui_hidden = !state.gui_hidden;
+
+                return 0;
             }
+            WM_RBUTTONUP => {
+                SetForegroundWindow(hwnd);
+                show_popup_menu(hwnd, state);
+
+                return 0;
+            }
+            _ => {}
+        },
+        WM_HIDE_GUI => {
+            state.gui_hidden = true;
+
+            ShowWindow(*state.gui_handle.as_ref().unwrap(), SW_HIDE);
 
             return 0;
         }
@@ -356,7 +401,7 @@ unsafe extern "system" fn callback(
     DefWindowProcW(hwnd, msg, wparam, lparam)
 }
 
-unsafe extern "system" fn wndenumproc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+unsafe extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
     let mut state = &mut *(lparam as *mut TrayState);
 
     let mut info: WINDOWINFO = mem::zeroed();

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -193,10 +193,6 @@ unsafe fn remove_icon(hwnd: HWND) {
 }
 
 unsafe fn show_popup_menu(hwnd: HWND, state: &TrayState) {
-    if state.about_shown {
-        return;
-    }
-
     let menu = CreatePopupMenu();
 
     let hidden = state.hidden;
@@ -307,12 +303,13 @@ unsafe extern "system" fn callback(
             PostQuitMessage(0);
         }
         WM_COMMAND => {
-            if state.about_shown {
-                return 1;
-            }
-
             match LOWORD(wparam as u32) {
                 ID_ABOUT => {
+                    // Don't show if already up
+                    if state.about_shown {
+                        return 1;
+                    }
+
                     state.about_shown = true;
 
                     show_about();

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -2,7 +2,7 @@ use std::mem;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, SyncSender};
-use std::thread::{self};
+use std::thread;
 
 use once_cell::sync::OnceCell;
 use winapi::shared::minwindef::{BOOL, LOWORD, LPARAM, LRESULT, UINT, WPARAM};

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -201,10 +201,7 @@ unsafe fn display_balloon_message(hwnd: HWND, message: &str) {
     icon_data.cbSize = mem::size_of::<NOTIFYICONDATAW>() as u32;
     icon_data.hWnd = hwnd;
     icon_data.uID = 1;
-    //icon_data.uCallbackMessage = WM_APP;
-    icon_data.uFlags = NIF_INFO; // NIF_ICON | NIF_MESSAGE | NIF_TIP;
-                                 //icon_data.hIcon = icon_handle;
-                                 //icon_data.szTip = tooltip_array;
+    icon_data.uFlags = NIF_INFO;
     icon_data.szInfo = info;
     icon_data.dwInfoFlags = NIIF_NONE | NIIF_NOSOUND;
 


### PR DESCRIPTION
Resolves our biggest request, sys-tray for windows!

## Proposed Changes
  - New setting "Close to System Tray" for Windows
  - When this is selected, a system tray icon will be created.
  - Pressing close will hide Ajour. It can be opened by double clicking the tray icon, or right clicking tray icon -> show
  - When enabled, Ajour can only be closed via right click tray icon -> exit (we can't hook / override the Minimize button w/ Iced but as of 0.3, we can with the Close icon).
 

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
