### PR TITLE
Feat/avoid multiple instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows: Only one instance of Ajour can be launched at a time.
+
 ## [1.1.0] - 2021-04-15
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ mod command;
 mod gui;
 mod localization;
 #[cfg(target_os = "windows")]
+mod process;
+#[cfg(target_os = "windows")]
 mod tray;
 
 use ajour_core::config::Config;
@@ -69,6 +71,10 @@ pub fn main() {
     log_panics::init();
 
     log::info!("Ajour {} has started.", VERSION);
+
+    // Ensures another instance of Ajour isn't already running.
+    #[cfg(target_os = "windows")]
+    process::avoid_multiple_instances();
 
     match opts.command {
         Some(command) => {

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,89 @@
+use std::ffi::c_void;
+use std::path::PathBuf;
+
+use ajour_core::fs::PersistentData;
+use serde::{Deserialize, Serialize};
+use winapi::{
+    shared::winerror::WAIT_TIMEOUT,
+    um::{
+        processthreadsapi::{GetCurrentProcess, GetCurrentProcessId, OpenProcess},
+        synchapi::WaitForSingleObject,
+        winbase::QueryFullProcessImageNameW,
+        winnt::{PROCESS_QUERY_LIMITED_INFORMATION, SYNCHRONIZE},
+    },
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Process {
+    pid: u32,
+    name: String,
+}
+
+impl PersistentData for Process {
+    fn relative_path() -> PathBuf {
+        PathBuf::from("pid")
+    }
+}
+
+pub fn avoid_multiple_instances() {
+    if process_already_running() {
+        log::info!("Another instance of Ajour is already running. Exiting...");
+        std::process::exit(0);
+    } else {
+        // Otherwise this is only instance. Save info about this process to the
+        // pid file so future launches of Ajour can detect this running process.
+        save_current_process_file();
+    }
+}
+
+fn process_already_running() -> bool {
+    let old_process = if let Ok(process) = Process::load() {
+        process
+    } else {
+        return false;
+    };
+
+    unsafe {
+        let handle = OpenProcess(
+            SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+            0,
+            old_process.pid,
+        );
+
+        if let Some(name) = get_process_name(handle) {
+            if name == old_process.name {
+                let status = WaitForSingleObject(handle, 0);
+
+                return status == WAIT_TIMEOUT;
+            }
+        }
+    }
+
+    false
+}
+
+fn save_current_process_file() {
+    unsafe {
+        let handle = GetCurrentProcess();
+        let pid = GetCurrentProcessId();
+
+        if let Some(name) = get_process_name(handle) {
+            let process = Process { pid, name };
+
+            let _ = process.save();
+        }
+    }
+}
+
+unsafe fn get_process_name(handle: *mut c_void) -> Option<String> {
+    let mut size = 256;
+    let mut buffer = [0u16; 256];
+
+    let status = QueryFullProcessImageNameW(handle, 0, buffer.as_mut_ptr(), &mut size);
+
+    if status != 0 {
+        String::from_utf16(&buffer[..(size as usize).min(buffer.len())]).ok()
+    } else {
+        None
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -44,6 +44,13 @@ fn process_already_running() -> bool {
     };
 
     unsafe {
+        let current_pid = GetCurrentProcessId();
+
+        // In case new process somehow got recycled PID of old process
+        if current_pid == old_process.pid {
+            return false;
+        }
+
         let handle = OpenProcess(
             SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
             0,

--- a/src/process.rs
+++ b/src/process.rs
@@ -30,7 +30,7 @@ pub fn avoid_multiple_instances() {
         log::info!("Another instance of Ajour is already running. Exiting...");
         std::process::exit(0);
     } else {
-        // Otherwise this is only instance. Save info about this process to the
+        // Otherwise this is the only instance. Save info about this process to the
         // pid file so future launches of Ajour can detect this running process.
         save_current_process_file();
     }


### PR DESCRIPTION
Resolves #624

## Proposed Changes
  - Exit if another instance of Ajour is running (on Windows)
  - Ajour will now write to a `pid` file the PID of the process and name of the executable.
  - When Ajour launches, it'll check the `pid` file and see if a process for that PID is running from that same executable name.
  - If so, the current process will exit
  - If not, the current process will overwrite the `pid` file with it's own info and continue to run

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
