### PR TITLE
Fix/gitlab url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and `Removed`.
   - Polish (thanks KasprzykM)
 - Ability to select Screenshots when backing up.
 
+### Fixed
+
+- Fixed error importing Gitlab addons from repos under a nested subgroup
+
 ## [1.2.0] - 2021-05-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "serde_yaml",
  "tar",
  "thiserror",
+ "urlencoding",
  "walkdir",
  "zip",
  "zstd",
@@ -3990,6 +3991,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
 
 [[package]]
 name = "value-bag"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -48,6 +48,7 @@ path-slash = "0.1.4"
 tar = "0.4.33"
 zstd = { version = "0.6.1", features = ["zstdmt"] }
 num_cpus = "1.13.0"
+urlencoding = "1.3.3"
 
 iced_native = { version = "0.4.0", optional = true }
 


### PR DESCRIPTION
Resolves #651

## Proposed Changes
  - Pass the entire Gitlab url path as url encoded to API endpoint

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
