### PR TITLE
feat: migration to new catalog repo

### DIFF
--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -41,7 +41,7 @@ async fn get_catalog_addons_from(
         }
         status => {
             log::error!("Catalog failed to download with status: {}", status);
-            return Err(DownloadError::CatalogFailed);
+            Err(DownloadError::CatalogFailed)
         }
     }
 }

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -85,8 +85,7 @@ pub struct Catalog {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Version {
     pub flavor: Flavor,
-    #[serde(deserialize_with = "null_to_default::deserialize")]
-    pub game_version: String,
+    pub game_version: Option<String>,
     #[serde(deserialize_with = "date_parser::deserialize")]
     pub date: Option<DateTime<Utc>>,
 }

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -260,7 +260,7 @@ mod tests {
     fn test_null_fields() {
         let tests = [
             r"[]",
-            r#"[{"id": null,"websiteUrl": null,"dateReleased":"2020-11-20T02:29:43.46Z","name": null,"summary": null,"numberOfDownloads": null,"categories": null,"flavors": null,"gameVersions": null,"source":"curse"}]"#,
+            r#"[{"id": null,"url": null,"name": null,"summary": null,"number_of_downloads": null,"categories": null,"flavors": null,"versions": null,"source":"Curse"}]"#,
         ];
 
         for test in tests.iter() {
@@ -281,23 +281,21 @@ mod tests {
             // Will return 0 results
             r#"null"#,
             // Will return 2 results
-            r#"[{"gameVersion": "asdf", "flavor": "classic"}, {"gameVersion": "asdf", "flavor": "retail"}]"#,
+            r#"[{"game_version": "asdf", "flavor": "classic", "date": "2000-01-01 00:00:00"}, {"game_version": "asdf", "flavor": "retail", "date": "2000-01-01 00:00:00"}]"#,
             // Will return 2 results, gameVersion as null will be String::default
-            r#"[{"gameVersion": "asdf", "flavor": "classic"}, {"gameVersion": null, "flavor": "retail"}]"#,
-            // Test skipping when GameVersion has an unknown flavor variant. Will return only first result.
-            r#"[{"gameVersion": "asdf", "flavor": "classic"}, {"gameVersion": "asdf", "flavor": "unknown"}]"#,
+            r#"[{"game_version": "asdf", "flavor": "classic", "date": "2000-01-01 00:00:00"}, {"game_version": null, "flavor": "retail", "date": "2000-01-01 00:00:00"}]"#,
             // All other deser error on elements will fail... missing field
-            r#"[{"gameVersion": "asdf", "flavor": "classic"}, {"gameVersion": "asdf"}]"#,
+            r#"[{"game_version": "asdf", "flavor": "classic", "date": "2000-01-01 00:00:00"}, {"game_version": "asdf", "date": "2000-01-01 00:00:00"}]"#,
             // All other deser error on elements will fail... null flavor
-            r#"[{"gameVersion": "asdf", "flavor": "classic"}, {"gameVersion": "asdf", "flavor": null}]"#,
+            r#"[{"game_version": "asdf", "flavor": "classic", "date": "2000-01-01 00:00:00"}, {"game_version": "asdf", "flavor": null, "date": "2000-01-01 00:00:00"}]"#,
             // All other deser error on elements will fail... invalid type for a field
-            r#"[{"gameVersion": "asdf", "flavor": "classic"}, {"gameVersion": {}, "flavor": "unknown"}]"#,
+            r#"[{"game_version": "asdf", "flavor": "classic", "date": "2000-01-01 00:00:00"}, {"game_version": {}, "flavor": "unknown", "date": "2000-01-01 00:00:00"}]"#,
         ];
 
         for (idx, test) in tests.iter().enumerate() {
             let result = serde_json::from_str::<Test>(test);
             match idx {
-                _ if idx < 5 => {
+                _ if idx < 4 => {
                     dbg!(&result);
                     assert!(result.is_ok());
                 }

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -62,8 +62,6 @@ pub enum Source {
     Tukui,
     WowI,
     TownlongYak,
-    #[serde(other)]
-    Other,
 }
 
 impl std::fmt::Display for Source {
@@ -73,9 +71,6 @@ impl std::fmt::Display for Source {
             Source::Tukui => "Tukui",
             Source::WowI => "WowInterface",
             Source::TownlongYak => "TownlongYak",
-
-            // This is a fallback option.
-            Source::Other => "Unknown",
         };
         write!(f, "{}", s)
     }

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -375,12 +375,11 @@ async fn get_curse_fingerprint_info(
         // Remove all addon folders that exist in the cache, since we
         // will extract the proper repository to query from the cache entry
         .filter(|folder| {
-            cache_entries
+            !cache_entries
                 .iter()
                 .map(|e| &e.folder_names)
                 .flatten()
-                .position(|name| name == &folder.id)
-                .is_none()
+                .any(|name| name == &folder.id)
         })
         .filter_map(|folder| folder.fingerprint)
         .collect();

--- a/src/gui/element/catalog.rs
+++ b/src/gui/element/catalog.rs
@@ -117,7 +117,7 @@ pub fn data_row_container<'a, 'b>(
     let install_button_state = &mut addon.install_button_state;
 
     let flavor_exists_for_addon = addon_data
-        .game_versions
+        .versions
         .iter()
         .any(|gc| gc.flavor == config.wow.flavor.base_flavor());
 
@@ -276,12 +276,12 @@ pub fn data_row_container<'a, 'b>(
         .next()
     {
         let game_version_text = addon_data
-            .game_versions
+            .versions
             .iter()
-            .find(|gv| gv.flavor == config.wow.flavor.base_flavor())
-            .map(|gv| match addon_data.source {
-                Source::TownlongYak => format_interface_into_game_version(&gv.game_version[..]),
-                _ => gv.game_version.clone(),
+            .find(|v| v.flavor == config.wow.flavor.base_flavor())
+            .map(|v| match addon_data.source {
+                Source::TownlongYak => format_interface_into_game_version(&v.game_version[..]),
+                _ => v.game_version.clone(),
             })
             .unwrap_or_else(|| "-".to_owned());
 
@@ -308,7 +308,13 @@ pub fn data_row_container<'a, 'b>(
         })
         .next()
     {
-        let release_date_text: String = if let Some(date_released) = addon_data.date_released {
+        let version_date = addon_data
+            .versions
+            .iter()
+            .find(|v| v.flavor == config.wow.flavor.base_flavor())
+            .map(|v| v.date)
+            .flatten();
+        let release_date_text: String = if let Some(date_released) = version_date {
             let f = localized_timeago_formatter();
             let now = Local::now();
             f.convert_chrono(date_released, now)
@@ -393,9 +399,7 @@ pub fn data_row_container<'a, 'b>(
     let mut table_row = TableRow::new(row)
         .width(Length::Fill)
         .inner_row_height(default_row_height)
-        .on_press(move |_| {
-            Message::Interaction(Interaction::OpenLink(addon_data.website_url.clone()))
-        });
+        .on_press(move |_| Message::Interaction(Interaction::OpenLink(addon_data.url.clone())));
 
     if is_odd == Some(true) {
         table_row = table_row.style(style::TableRowAlternate(color_palette))

--- a/src/gui/element/catalog.rs
+++ b/src/gui/element/catalog.rs
@@ -279,11 +279,13 @@ pub fn data_row_container<'a, 'b>(
             .versions
             .iter()
             .find(|v| v.flavor == config.wow.flavor.base_flavor())
-            .map(|v| match addon_data.source {
-                Source::TownlongYak => format_interface_into_game_version(&v.game_version[..]),
-                _ => v.game_version.clone(),
+            .map(|v| v.game_version.clone())
+            .flatten()
+            .map(|gv| match addon_data.source {
+                Source::TownlongYak => format_interface_into_game_version(&gv[..]),
+                _ => gv,
             })
-            .unwrap_or_else(|| "-".to_owned());
+            .unwrap_or_else(|| localized_string("unknown"));
 
         let game_version_text = Text::new(game_version_text).size(DEFAULT_FONT_SIZE);
         let game_version_container = Container::new(game_version_text)

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1929,7 +1929,6 @@ impl std::fmt::Display for CatalogSource {
                 catalog::Source::Tukui => "Tukui",
                 catalog::Source::WowI => "WowInterface",
                 catalog::Source::TownlongYak => "TownlongYak",
-                catalog::Source::Other => panic!("Unsupported catalog source"),
             },
             CatalogSource::None => empty_display_string,
         };

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2771,21 +2771,49 @@ fn sort_catalog_addons(
         }
         (CatalogColumnKey::Install, SortDirection::Asc) => {}
         (CatalogColumnKey::Install, SortDirection::Desc) => {}
-        (CatalogColumnKey::DateReleased, SortDirection::Asc) => {
-            addons.sort_by(|a, b| a.addon.date_released.cmp(&b.addon.date_released));
-        }
-        (CatalogColumnKey::DateReleased, SortDirection::Desc) => {
-            addons.sort_by(|a, b| a.addon.date_released.cmp(&b.addon.date_released).reverse());
-        }
+        (CatalogColumnKey::DateReleased, SortDirection::Asc) => addons.sort_by(|a, b| {
+            let v_a = a
+                .addon
+                .versions
+                .iter()
+                .find(|v| &v.flavor == flavor)
+                .map(|v| v.date)
+                .flatten();
+            let v_b = b
+                .addon
+                .versions
+                .iter()
+                .find(|v| &v.flavor == flavor)
+                .map(|v| v.date)
+                .flatten();
+            v_a.cmp(&v_b)
+        }),
+        (CatalogColumnKey::DateReleased, SortDirection::Desc) => addons.sort_by(|a, b| {
+            let v_a = a
+                .addon
+                .versions
+                .iter()
+                .find(|v| &v.flavor == flavor)
+                .map(|v| v.date)
+                .flatten();
+            let v_b = b
+                .addon
+                .versions
+                .iter()
+                .find(|v| &v.flavor == flavor)
+                .map(|v| v.date)
+                .flatten();
+            v_a.cmp(&v_b).reverse()
+        }),
         (CatalogColumnKey::GameVersion, SortDirection::Asc) => addons.sort_by(|a, b| {
-            let gv_a = a.addon.game_versions.iter().find(|gc| &gc.flavor == flavor);
-            let gv_b = b.addon.game_versions.iter().find(|gc| &gc.flavor == flavor);
-            gv_a.cmp(&gv_b)
+            let v_a = a.addon.versions.iter().find(|v| &v.flavor == flavor);
+            let v_b = b.addon.versions.iter().find(|v| &v.flavor == flavor);
+            v_a.cmp(&v_b)
         }),
         (CatalogColumnKey::GameVersion, SortDirection::Desc) => addons.sort_by(|a, b| {
-            let gv_a = a.addon.game_versions.iter().find(|gc| &gc.flavor == flavor);
-            let gv_b = b.addon.game_versions.iter().find(|gc| &gc.flavor == flavor);
-            gv_a.cmp(&gv_b).reverse()
+            let v_a = a.addon.versions.iter().find(|v| &v.flavor == flavor);
+            let v_b = b.addon.versions.iter().find(|v| &v.flavor == flavor);
+            v_a.cmp(&v_b).reverse()
         }),
         (CatalogColumnKey::Categories, SortDirection::Desc) => {
             addons.sort_by(|a, b| {
@@ -2897,7 +2925,7 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
         let mut catalog_rows_and_score = catalog
             .addons
             .iter()
-            .filter(|a| !a.game_versions.is_empty())
+            .filter(|a| !a.versions.is_empty())
             .filter_map(|a| {
                 if let Some(query) = &query {
                     let title_score = fuzzy_matcher
@@ -2919,11 +2947,7 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
                     Some((a, 0))
                 }
             })
-            .filter(|(a, _)| {
-                a.game_versions
-                    .iter()
-                    .any(|gc| gc.flavor == flavor.base_flavor())
-            })
+            .filter(|(a, _)| a.versions.iter().any(|v| v.flavor == flavor.base_flavor()))
             .filter(|(a, _)| Some(a.source) == *source)
             .filter(|(a, _)| match category {
                 CatalogCategory::All => true,

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2516,9 +2516,6 @@ async fn perform_fetch_latest_addon(
                     catalog::Source::Tukui => RepositoryKind::Tukui,
                     catalog::Source::WowI => RepositoryKind::WowI,
                     catalog::Source::TownlongYak => RepositoryKind::TownlongYak,
-                    catalog::Source::Other => {
-                        panic!("Unsupported catalog source")
-                    }
                 };
 
                 RepositoryPackage::from_repo_id(flavor, kind, id)?


### PR DESCRIPTION
## Proposed Changes
  - This is a migration from github.com/ajour/ajour-catalog to github.com/ajour/catalog.

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [x] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
