### PR TITLE
Fix/inconsistent styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and `Removed`.
 ### Fixed
 
 - Fixed error importing Gitlab addons from repos under a nested subgroup
+- Fixed inconsistent size & styling in the segmented mode button
 
 ## [1.2.0] - 2021-05-18
 

--- a/src/gui/element/menu.rs
+++ b/src/gui/element/menu.rs
@@ -255,14 +255,14 @@ pub fn data_container<'a>(
         .push(install_mode_button.map(Message::Interaction))
         .spacing(1);
 
-    let mut segmented_mode_row = Row::new().push(my_addons_table_row);
+    let mut segmented_mode_row = Row::new().push(my_addons_table_row).spacing(1);
 
     if weak_auras_is_installed {
         segmented_mode_row = segmented_mode_row.push(my_wago_table_row);
     }
 
     let segmented_mode_container = Container::new(segmented_mode_row)
-        .padding(1)
+        .padding(2)
         .style(style::SegmentedContainer(color_palette));
 
     let segmented_addon_container = Container::new(segmented_addons_row)

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -534,8 +534,8 @@ impl table_row::StyleSheet for SegmentTableRow {
         table_row::Style {
             text_color: None,
             background: Some(Background::Color(self.0.base.foreground)),
-            border_radius: 3.0,
-            border_width: 1.0,
+            border_radius: 2.0,
+            border_width: 0.0,
             border_color: Color::TRANSPARENT,
             offset_left: 0.0,
             offset_right: 0.0,
@@ -559,8 +559,8 @@ impl table_row::StyleSheet for SelectedSegmentTableRow {
         table_row::Style {
             text_color: None,
             background: Some(Background::Color(self.0.normal.primary)),
-            border_radius: 3.0,
-            border_width: 1.0,
+            border_radius: 2.0,
+            border_width: 0.0,
             border_color: Color::TRANSPARENT,
             offset_left: 0.0,
             offset_right: 0.0,


### PR DESCRIPTION
Fixes inconsistent sizing & styling on the segmented mode button.

### Before
![Screenshot from 2021-06-29 10:39:15](https://user-images.githubusercontent.com/10239377/123843348-acd9a100-d8c6-11eb-8a0b-2438a10ba43d.png)

### After
![Screenshot from 2021-06-29 10:38:46](https://user-images.githubusercontent.com/10239377/123843358-b06d2800-d8c6-11eb-812c-bf0a52c88613.png)



## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
