### PR TITLE
Fixed old theme link (I think)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ respecting and open source. Ajour currently supports Windows, macOS and Linux.
 - Supports both Retail, Classic Era, Classic Tbc, Ptr and Beta versions of
   World of Warcraft
 - 10+ handcrafted themes to choose between
-  - [Ability to add your own custom themes](./THEMES.md)
+  - [Ability to add your own custom themes](#themes)
 - Ability to backup your whole UI, including all settings from WTF
 - Ability to run as a [command line application](#command-line) for advanced users
 - WeakAuras and Plater import strings from [Wago.io](https://wago.io/) will automatically


### PR DESCRIPTION
Resolves #

## Proposed Changes
  - Found a link to a deleted THEMES.md updated to scroll down to themes section instead.

## Checklist

- [x] Doc bug (no platform testing required)
- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
