### PR TITLE
feat: better ui for displaying errors to the user

### DIFF
--- a/src/gui/element/menu.rs
+++ b/src/gui/element/menu.rs
@@ -230,7 +230,7 @@ pub fn data_container<'a>(
         }
     }
 
-    if matches!(myaddons_state, Some(State::Start)) {
+    if matches!(myaddons_state, None) {
         catalog_mode_button =
             catalog_mode_button.style(style::DisabledDefaultButton(color_palette));
         install_mode_button =

--- a/src/gui/element/menu.rs
+++ b/src/gui/element/menu.rs
@@ -44,10 +44,7 @@ pub fn data_container<'a>(
     valid_flavors.sort();
 
     // State.
-    let myaddons_state = state
-        .get(&Mode::MyAddons(flavor))
-        .cloned()
-        .unwrap_or_default();
+    let myaddons_state = state.get(&Mode::MyAddons(flavor));
 
     // A row contain general settings.
     let mut settings_row = Row::new()
@@ -233,7 +230,7 @@ pub fn data_container<'a>(
         }
     }
 
-    if matches!(myaddons_state, State::Start) {
+    if matches!(myaddons_state, Some(State::Start)) {
         catalog_mode_button =
             catalog_mode_button.style(style::DisabledDefaultButton(color_palette));
         install_mode_button =

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -775,10 +775,8 @@ pub fn menu_container<'a>(
     config: &Config,
 ) -> Container<'a, Message> {
     // MyAddons state.
-    let state = state
-        .get(&Mode::MyAddons(flavor))
-        .cloned()
-        .unwrap_or_default();
+    // TODO: lets try to make this prettier.
+    let state = state.get(&Mode::MyAddons(flavor));
 
     // A row contain general settings.
     let mut settings_row = Row::new().align_items(Align::Center);
@@ -817,7 +815,7 @@ pub fn menu_container<'a>(
     // Enable refresh_button if:
     //   - No addon is performing any task.
     //   - Mode state isn't start or loading
-    if !addons_performing_actions && !matches!(state, State::Start | State::Loading) {
+    if !addons_performing_actions && !matches!(state, Some(State::Start) | Some(State::Loading)) {
         refresh_button = refresh_button.on_press(Interaction::Refresh(Mode::MyAddons(flavor)));
     }
 
@@ -829,7 +827,7 @@ pub fn menu_container<'a>(
     let ignored_addons = config.addons.ignored.get(&flavor);
 
     let status_text = match state {
-        State::Ready => {
+        Some(State::Ready) => {
             let flavor = flavor.to_string().to_lowercase();
             let addons_count = addons
                 .iter()

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -775,7 +775,6 @@ pub fn menu_container<'a>(
     config: &Config,
 ) -> Container<'a, Message> {
     // MyAddons state.
-    // TODO: lets try to make this prettier.
     let state = state.get(&Mode::MyAddons(flavor));
 
     // A row contain general settings.
@@ -815,7 +814,7 @@ pub fn menu_container<'a>(
     // Enable refresh_button if:
     //   - No addon is performing any task.
     //   - Mode state isn't start or loading
-    if !addons_performing_actions && !matches!(state, Some(State::Start) | Some(State::Loading)) {
+    if !addons_performing_actions && !matches!(state, None | Some(State::Loading)) {
         refresh_button = refresh_button.on_press(Interaction::Refresh(Mode::MyAddons(flavor)));
     }
 

--- a/src/gui/element/my_weakauras.rs
+++ b/src/gui/element/my_weakauras.rs
@@ -34,10 +34,7 @@ pub fn menu_container<'a>(
     chosen_account: Option<String>,
 ) -> Container<'a, Message> {
     // MyWeakAuras state.
-    let state = state
-        .get(&Mode::MyWeakAuras(flavor))
-        .cloned()
-        .unwrap_or_default();
+    let state = state.get(&Mode::MyWeakAuras(flavor));
 
     // A row contain general settings.
     let mut row = Row::new().align_items(Align::Center);
@@ -73,7 +70,7 @@ pub fn menu_container<'a>(
     let update_all_button: Element<Interaction> = update_all_button.into();
     let refresh_button: Element<Interaction> = refresh_button.into();
     let status_text = match state {
-        State::Ready => {
+        Some(State::Ready) => {
             if updates_queued {
                 Text::new(localized_string("weakaura-updates-queued")).size(DEFAULT_FONT_SIZE)
             } else {

--- a/src/gui/element/status.rs
+++ b/src/gui/element/status.rs
@@ -1,6 +1,6 @@
 use {
     super::{DEFAULT_FONT_SIZE, DEFAULT_PADDING},
-    crate::gui::{style, Interaction, Message, State},
+    crate::gui::{style, Interaction, Message},
     crate::localization::localized_string,
     ajour_core::theme::ColorPalette,
     iced::{

--- a/src/gui/element/status.rs
+++ b/src/gui/element/status.rs
@@ -36,7 +36,7 @@ pub fn data_container<'a>(
         .push(Space::new(Length::Units(0), Length::Units(2)))
         .push(description_container);
 
-    if let (_, Some(btn_state)) = (State::Start, onboarding_directory_btn_state) {
+    if let Some(btn_state) = onboarding_directory_btn_state {
         let onboarding_button_title_container =
             Container::new(Text::new(localized_string("select-directory")).size(DEFAULT_FONT_SIZE))
                 .center_x()

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -43,15 +43,14 @@ static WINDOW_ICON: &[u8] = include_bytes!("../../resources/windows/ajour.ico");
 
 #[derive(Debug)]
 pub enum State {
-    Start,
     Ready,
     Loading,
-    Error(Option<anyhow::Error>),
+    Error(anyhow::Error),
 }
 
 impl Default for State {
     fn default() -> Self {
-        State::Start
+        State::Ready
     }
 }
 
@@ -1007,12 +1006,6 @@ impl Application for Ajour {
             Mode::MyAddons(flavor) => {
                 let state = self.state.get(&Mode::MyAddons(flavor));
                 match state {
-                    Some(State::Start) => Some(element::status::data_container(
-                        color_palette,
-                        &localized_string("setup-ajour-title")[..],
-                        &localized_string("setup-ajour-description")[..],
-                        Some(&mut self.onboarding_directory_btn_state),
-                    )),
                     Some(State::Loading) => {
                         let flavor = flavor.to_string().to_lowercase();
                         let mut vars = HashMap::new();
@@ -1044,7 +1037,12 @@ impl Application for Ajour {
                         }
                     }
                     Some(State::Error(error)) => None,
-                    None => None,
+                    None => Some(element::status::data_container(
+                        color_palette,
+                        &localized_string("setup-ajour-title")[..],
+                        &localized_string("setup-ajour-description")[..],
+                        Some(&mut self.onboarding_directory_btn_state),
+                    )),
                 }
             }
             Mode::Settings => None,
@@ -1054,12 +1052,6 @@ impl Application for Ajour {
                 let state = self.state.get(&Mode::MyWeakAuras(flavor));
 
                 match state {
-                    Some(State::Start) => Some(element::status::data_container(
-                        color_palette,
-                        &localized_string("setup-weakauras-title")[..],
-                        &localized_string("setup-weakauras-description")[..],
-                        None,
-                    )),
                     Some(State::Loading) => {
                         let flavor = flavor.to_string().to_lowercase();
                         let mut vars = HashMap::new();
@@ -1091,7 +1083,12 @@ impl Application for Ajour {
                         }
                     }
                     Some(State::Error(error)) => None,
-                    None => None,
+                    None => Some(element::status::data_container(
+                        color_palette,
+                        &localized_string("setup-weakauras-title")[..],
+                        &localized_string("setup-weakauras-description")[..],
+                        None,
+                    )),
                 }
             }
             Mode::Catalog => {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -41,11 +41,12 @@ use strfmt::strfmt;
 use element::{DEFAULT_FONT_SIZE, DEFAULT_PADDING};
 static WINDOW_ICON: &[u8] = include_bytes!("../../resources/windows/ajour.ico");
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub enum State {
     Start,
     Ready,
     Loading,
+    Error(Option<anyhow::Error>),
 }
 
 impl Default for State {
@@ -239,8 +240,11 @@ pub struct Ajour {
 
 impl Default for Ajour {
     fn default() -> Self {
+        let mut state = HashMap::new();
+        state.insert(Mode::Catalog, State::Loading);
+
         Self {
-            state: [(Mode::Catalog, State::Loading)].iter().cloned().collect(),
+            state,
             error: None,
             mode: Mode::MyAddons(Flavor::Retail),
             addons: HashMap::new(),
@@ -1001,19 +1005,15 @@ impl Application for Ajour {
 
         let container: Option<Container<Message>> = match self.mode {
             Mode::MyAddons(flavor) => {
-                let state = self
-                    .state
-                    .get(&Mode::MyAddons(flavor))
-                    .cloned()
-                    .unwrap_or_default();
+                let state = self.state.get(&Mode::MyAddons(flavor));
                 match state {
-                    State::Start => Some(element::status::data_container(
+                    Some(State::Start) => Some(element::status::data_container(
                         color_palette,
                         &localized_string("setup-ajour-title")[..],
                         &localized_string("setup-ajour-description")[..],
                         Some(&mut self.onboarding_directory_btn_state),
                     )),
-                    State::Loading => {
+                    Some(State::Loading) => {
                         let flavor = flavor.to_string().to_lowercase();
                         let mut vars = HashMap::new();
                         vars.insert("flavor".to_string(), &flavor);
@@ -1026,7 +1026,7 @@ impl Application for Ajour {
                             None,
                         ))
                     }
-                    State::Ready => {
+                    Some(State::Ready) => {
                         let flavor = flavor.to_string().to_lowercase();
                         let mut vars = HashMap::new();
                         vars.insert("flavor".to_string(), &flavor);
@@ -1043,26 +1043,24 @@ impl Application for Ajour {
                             None
                         }
                     }
+                    Some(State::Error(error)) => None,
+                    None => None,
                 }
             }
             Mode::Settings => None,
             Mode::About => None,
             Mode::Install => None,
             Mode::MyWeakAuras(flavor) => {
-                let state = self
-                    .state
-                    .get(&Mode::MyWeakAuras(flavor))
-                    .cloned()
-                    .unwrap_or_default();
+                let state = self.state.get(&Mode::MyWeakAuras(flavor));
 
                 match state {
-                    State::Start => Some(element::status::data_container(
+                    Some(State::Start) => Some(element::status::data_container(
                         color_palette,
                         &localized_string("setup-weakauras-title")[..],
                         &localized_string("setup-weakauras-description")[..],
                         None,
                     )),
-                    State::Loading => {
+                    Some(State::Loading) => {
                         let flavor = flavor.to_string().to_lowercase();
                         let mut vars = HashMap::new();
                         vars.insert("flavor".to_string(), &flavor);
@@ -1075,7 +1073,7 @@ impl Application for Ajour {
                             None,
                         ))
                     }
-                    State::Ready => {
+                    Some(State::Ready) => {
                         if !has_auras {
                             let flavor = flavor.to_string();
                             let mut vars = HashMap::new();
@@ -1092,19 +1090,20 @@ impl Application for Ajour {
                             None
                         }
                     }
+                    Some(State::Error(error)) => None,
+                    None => None,
                 }
             }
             Mode::Catalog => {
-                let state = self.state.get(&Mode::Catalog).cloned().unwrap_or_default();
+                let state = self.state.get(&Mode::Catalog);
                 match state {
-                    State::Start => None,
-                    State::Loading => Some(element::status::data_container(
+                    Some(State::Loading) => Some(element::status::data_container(
                         color_palette,
                         &localized_string("loading")[..],
                         &localized_string("loading-catalog")[..],
                         None,
                     )),
-                    State::Ready => None,
+                    _ => None,
                 }
             }
         };

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1036,7 +1036,22 @@ impl Application for Ajour {
                             None
                         }
                     }
-                    Some(State::Error(error)) => None,
+                    Some(State::Error(error)) => {
+                        let error_title = format!("{}", error);
+                        let mut error_description = String::new();
+                        let cause = error.chain().last();
+
+                        if let Some(cause) = cause {
+                            error_description.push_str(&format!("Caused by {}", cause)[..]);
+                        }
+
+                        Some(element::status::data_container(
+                            color_palette,
+                            &error_title,
+                            &error_description,
+                            None,
+                        ))
+                    }
                     None => Some(element::status::data_container(
                         color_palette,
                         &localized_string("setup-ajour-title")[..],
@@ -1082,7 +1097,22 @@ impl Application for Ajour {
                             None
                         }
                     }
-                    Some(State::Error(error)) => None,
+                    Some(State::Error(error)) => {
+                        let error_title = format!("{}", error);
+                        let mut error_description = String::new();
+                        let cause = error.chain().last();
+
+                        if let Some(cause) = cause {
+                            error_description.push_str(&format!("Caused by {}", cause)[..]);
+                        }
+
+                        Some(element::status::data_container(
+                            color_palette,
+                            &error_title,
+                            &error_description,
+                            None,
+                        ))
+                    }
                     None => Some(element::status::data_container(
                         color_palette,
                         &localized_string("setup-weakauras-title")[..],
@@ -1100,6 +1130,22 @@ impl Application for Ajour {
                         &localized_string("loading-catalog")[..],
                         None,
                     )),
+                    Some(State::Error(error)) => {
+                        let error_title = format!("{}", error);
+                        let mut error_description = String::new();
+                        let cause = error.chain().last();
+
+                        if let Some(cause) = cause {
+                            error_description.push_str(&format!("Caused by {}", cause)[..]);
+                        }
+
+                        Some(element::status::data_container(
+                            color_palette,
+                            &error_title,
+                            &error_description,
+                            None,
+                        ))
+                    }
                     _ => None,
                 }
             }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -336,10 +336,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 // Save config.
                 let _ = &ajour.config.save();
 
-                let state = ajour.state.clone();
-                for (mode, _) in state {
+                for (mode, state) in ajour.state.iter_mut() {
                     if matches!(mode, Mode::MyAddons(_)) {
-                        ajour.state.insert(mode, State::Loading);
+                        *state = State::Loading;
                     }
                 }
 
@@ -787,6 +786,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
                 Err(error) => {
                     log_error(&error);
+                    ajour.error = Some(error);
                 }
             }
         }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -781,7 +781,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
                 Err(error) => {
                     log_error(&error);
-                    ajour.error = Some(error);
+                    ajour
+                        .state
+                        .insert(Mode::MyAddons(flavor), State::Error(error));
                 }
             }
         }
@@ -2003,7 +2005,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::CatalogDownloaded(error @ Err(_)) => {
             let error = error.context("Failed to download catalog").unwrap_err();
             log_error(&error);
-            ajour.error = Some(error);
+            ajour.state.insert(Mode::Catalog, State::Error(error));
         }
         Message::AddonCacheUpdated(error @ Err(_)) => {
             let error = error.context("Failed to update addon cache").unwrap_err();
@@ -2202,7 +2204,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 let error = error.context(strfmt(&fmt, &vars).unwrap()).unwrap_err();
 
                 log_error(&error);
-                ajour.error = Some(error);
+                ajour
+                    .state
+                    .insert(Mode::MyWeakAuras(flavor), State::Error(error));
             }
         },
         Message::AurasUpdated((flavor, result)) => match result {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -156,11 +156,6 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     ));
                 } else {
                     log::debug!("addon directory is not set, showing welcome screen");
-
-                    // Assume we are welcoming a user because directory is not set.
-                    let flavor = ajour.config.wow.flavor;
-                    ajour.state.insert(Mode::MyAddons(flavor), State::Start);
-
                     break;
                 }
             }


### PR DESCRIPTION
Resolves #649

## Proposed Changes
  - When encountering an error, it is now possible to attach it to the current mode, which will then display it on the screen rather than in the little error box top right. This means, e.g., in the case of problems reaching the host, we write that rather than "No addons found". See the picture below as an example. I've chosen to keep the error box top right because it is still used for updating, unpacking, hashing errors.

<img width="808" alt="Screenshot 2021-07-10 at 22 15 34" src="https://user-images.githubusercontent.com/2248455/125175482-c931e380-e1cc-11eb-90f1-7e0afa23846b.png">

- We don't have `State::Start` anymore, this made little sense anyway. We now have `Ready` `Loading` and `Error`.

## Checklist

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
