### PR TITLE
feat: only show Fonts backup option if exsist

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -158,7 +158,6 @@ impl Config {
 
     /// Return a `Option<PathBuf` to a directory.
     /// This will return none if no `wow_directory` is set in the config.
-    ///
     fn get_directory_for_flavor(
         &self,
         flavor: &Flavor,

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -127,7 +127,7 @@ impl Config {
     /// Returns a `Option<PathBuf>` to the directory containing the addons.
     /// This will return `None` if no `wow_directory` is set in the config.
     pub fn get_addon_directory_for_flavor(&self, flavor: &Flavor) -> Option<PathBuf> {
-        self.get_directory_for_flavor(flavor, "Interface/AddOns")
+        self.get_directory_for_flavor(flavor, "Interface/AddOns", true)
     }
 
     /// Returns a `Option<PathBuf>` to the directory which will hold the
@@ -139,25 +139,32 @@ impl Config {
 
     /// Returns a `Option<PathBuf>` to the Fonts directory.
     /// This will return `None` if no `wow_directory` is set in the config.
+    /// This is a optional folder, so it will not be created if nonexistent.
     pub fn get_fonts_directory_for_flavor(&self, flavor: &Flavor) -> Option<PathBuf> {
-        self.get_directory_for_flavor(flavor, "Fonts")
+        self.get_directory_for_flavor(flavor, "Fonts", false)
     }
 
     /// Returns a `Option<PathBuf>` to the WTF directory.
     /// This will return `None` if no `wow_directory` is set in the config.
     pub fn get_wtf_directory_for_flavor(&self, flavor: &Flavor) -> Option<PathBuf> {
-        self.get_directory_for_flavor(flavor, "WTF")
+        self.get_directory_for_flavor(flavor, "WTF", true)
     }
 
     /// Returns a `Option<PathBuf>` to the Screenshots directory.
     /// This will return `None` if no `wow_directory` is set in the config.
     pub fn get_screenshots_directory_for_flavor(&self, flavor: &Flavor) -> Option<PathBuf> {
-        self.get_directory_for_flavor(flavor, "Screenshots")
+        self.get_directory_for_flavor(flavor, "Screenshots", true)
     }
 
     /// Return a `Option<PathBuf` to a directory.
     /// This will return none if no `wow_directory` is set in the config.
-    fn get_directory_for_flavor(&self, flavor: &Flavor, relative_path: &str) -> Option<PathBuf> {
+    ///
+    fn get_directory_for_flavor(
+        &self,
+        flavor: &Flavor,
+        relative_path: &str,
+        create_if_nonexistent: bool,
+    ) -> Option<PathBuf> {
         let wow_flavor_dir = self.wow.directories.get(flavor);
         match wow_flavor_dir {
             Some(wow_flavor_dir) => {
@@ -182,7 +189,8 @@ impl Config {
                     }
                 }
 
-                if wow_flavor_dir.exists() && !dir.exists() {
+                // Create directory if missing, and it is allowed.
+                if wow_flavor_dir.exists() && (!dir.exists() && create_if_nonexistent) {
                     let _ = create_dir_all(&dir);
                 }
 

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -343,15 +343,25 @@ pub fn data_container<'a, 'b>(
             .style(style::NormalBackgroundContainer(color_palette));
 
         // Data row for the Backup directory selection.
-        let backup_directory_row = Row::new()
+        let mut backup_directory_row = Row::new()
             .align_items(Align::Center)
             .push(addon_folder_checkbox.map(Message::Interaction))
             .push(Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0)))
             .push(wtf_folder_checkbox.map(Message::Interaction))
             .push(Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0)))
-            .push(screenshots_folder_checkbox.map(Message::Interaction))
-            .push(Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0)))
-            .push(fonts_folder_checkbox.map(Message::Interaction))
+            .push(screenshots_folder_checkbox.map(Message::Interaction));
+
+        // Check if Fonts dir exists, since its a user generated folder.
+        // We only show this backup option if it's been created.
+        if let Some(fonts_dir) = config.get_fonts_directory_for_flavor(&config.wow.flavor) {
+            if fonts_dir.exists() {
+                backup_directory_row = backup_directory_row
+                    .push(Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0)))
+                    .push(fonts_folder_checkbox.map(Message::Interaction));
+            }
+        }
+
+        let backup_directory_row = backup_directory_row
             .push(Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0)))
             .push(config_folder_checkbox.map(Message::Interaction));
 


### PR DESCRIPTION
Since `Fonts` folder is a user generated folder, we only want to show the option to back it up if it exist.

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [ ] ~~Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users~~
