### PR TITLE
fix: parsing regexes coverted to raw strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Changed
+
+- Speed up parsing addons by improved regex expessions.
+
 ## [1.2.3] - 2021-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and `Removed`.
 
 ### Changed
 
-- Speed up parsing addons by improved regex expessions.
+- Speed up parsing addons by improving regex expessions.
 
 ## [1.2.3] - 2021-07-17
 

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -1004,32 +1004,31 @@ where
 }
 
 static RE_TOC_LINE: Lazy<regex::Regex> =
-    Lazy::new(|| regex::Regex::new(r"^##\s*(?P<key>.*?)\s*:\s?(?P<value>.*)").unwrap());
+    Lazy::new(|| regex::Regex::new(r#"^##\s*(?P<key>.*?)\s*:\s?(?P<value>.*)"#).unwrap());
 static RE_TOC_TITLE: Lazy<regex::Regex> =
-    Lazy::new(|| regex::Regex::new(r"\|(?:[a-fA-F\d]{9}|T[^|]*|t|r|$)").unwrap());
+    Lazy::new(|| regex::Regex::new(r#"\|(?:[a-fA-F\d]{9}|T[^|]*|t|r|$)"#).unwrap());
 static RE_PARSING_PATTERNS: Lazy<ParsingPatterns> = Lazy::new(|| {
     let mut file_parsing_regex = HashMap::new();
     file_parsing_regex.insert(
         ".xml".to_string(),
         (
-            regex::Regex::new("(?s)<!--.*?-->").unwrap(),
-            Regex::new("(?i)<(?:Include|Script)\\s+file=[\"\"']((?:(?<!\\.\\.).)+)[\"\"']\\s*/>")
-                .unwrap(),
+            regex::Regex::new(r#"(?s)<!--.*?-->"#).unwrap(),
+            Regex::new(r#"(?i)<(?:Include|Script)\s+file=["']((?:(?<!\.\.).)+)["']\s*/>"#).unwrap(),
         ),
     );
 
     file_parsing_regex.insert(
         ".toc".to_string(),
         (
-            regex::Regex::new("(?m)\\s*#.*$").unwrap(),
-            Regex::new("(?mi)^\\s*((?:(?<!\\.\\.).)+\\.(?:xml|lua))\\s*$").unwrap(),
+            regex::Regex::new(r#"(?m)\s*#.*$"#).unwrap(),
+            Regex::new(r#"(?mi)^\s*((?:(?<!\.\.).)+\.(?:xml|lua))\s*$"#).unwrap(),
         ),
     );
 
     ParsingPatterns {
-        extra_inclusion_regex: Regex::new(r"(?i)^[^/\\]+[/\\]Bindings\.xml$").unwrap(),
+        extra_inclusion_regex: Regex::new(r#"(?i)^[^/\\]+[/\\]Bindings\.xml$"#).unwrap(),
         initial_inclusion_regex: Regex::new(
-            r"(?i)^([^/\\]+)[/\\]\1(-mainline|-bcc|-classic)?\.toc$",
+            r#"(?i)^([^/\\]+)[/\\]\1(-mainline|-bcc|-classic)?\.toc$"#,
         )
         .unwrap(),
         file_parsing_regex,

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -1027,9 +1027,9 @@ static RE_PARSING_PATTERNS: Lazy<ParsingPatterns> = Lazy::new(|| {
     );
 
     ParsingPatterns {
-        extra_inclusion_regex: Regex::new("(?i)^[^/\\\\]+[/\\\\]Bindings\\.xml$").unwrap(),
+        extra_inclusion_regex: Regex::new(r"(?i)^[^/\\]+[/\\]Bindings\.xml$").unwrap(),
         initial_inclusion_regex: Regex::new(
-            "(?i)^([^/]+)[\\\\/]\\1(-mainline|-bcc|-classic)?\\.toc$",
+            r"(?i)^([^/\\]+)[/\\]\1(-mainline|-bcc|-classic)?\.toc$",
         )
         .unwrap(),
         file_parsing_regex,


### PR DESCRIPTION
## Proposed Changes
  - Changes relevant regexes to raw regexes (Thanks @Bananaman)

Note: this needs to be proper tested.

## Checklist

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
