### PR TITLE
Feature/no self update

### DIFF
--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -4,11 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Specify tag to create'
+        description: "Specify tag to create"
         required: true
 
 jobs:
-  
   build:
     name: Build
     strategy:
@@ -21,6 +20,10 @@ jobs:
           - target: windows-opengl
             os: windows-latest
             make: make binary OPENGL=1
+            binary_path: target/release/ajour.exe
+          - target: windows-noselfupdate
+            os: windows-latest
+            make: make binary NOSELFUPDATE=1
             binary_path: target/release/ajour.exe
 
           - target: linux-wgpu
@@ -48,6 +51,10 @@ jobs:
             os: macos-latest
             make: make tar OPENGL=1 MACOS=1
             binary_path: target/release/ajour.tar.gz
+          - target: macos-noselfupdate
+            os: macos-latest
+            make: make tar MACOS=1 NOSELFUPDATE=1
+            binary_path: target/release/ajour.tar.gz
 
     runs-on: ${{ matrix.target.os }}
 
@@ -60,7 +67,7 @@ jobs:
           override: true
 
       - name: Do we need linuxdeploy?
-        if: ${{ matrix.target.os == 'ubuntu-16.04' }} 
+        if: ${{ matrix.target.os == 'ubuntu-16.04' }}
         run: |
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
@@ -76,7 +83,7 @@ jobs:
 
       - name: Code signing
         if: ${{ matrix.target.os == 'windows-latest' }}
-        env: 
+        env:
           codesign_cert: ${{ secrets.CODESIGN_CERT }}
           codesign_cert_password: ${{ secrets.CODESIGN_CERT_PASSWORD }}
         run: |
@@ -125,6 +132,10 @@ jobs:
             artifact_name: ajour.exe
             asset_name: ajour-opengl.exe
             asset_type: application/x-dosexec
+          - artifact: windows-noselfupdate
+            artifact_name: ajour.exe
+            asset_name: ajour-noselfupdate.exe
+            asset_type: application/x-dosexec
 
           - artifact: linux-wgpu
             artifact_name: ajour.AppImage
@@ -150,6 +161,10 @@ jobs:
           - artifact: macos-opengl-tar
             artifact_name: ajour.tar.gz
             asset_name: ajour-opengl-macos.tar.gz
+            asset_type: application/gzip
+          - artifact: macos-noselfupdate
+            artifact_name: ajour.tar.gz
+            asset_name: ajour-noselfupdate-macos.tar.gz
             asset_type: application/gzip
 
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Packaging
+
+- Adds a new cargo feature flag `no-self-update`. When used, Ajour won't check for
+  newer updates.
+- Adds 2 new release assets, one for Windows and Macos, both with this feature
+  activated. These can be picked up by Chocolatey & Homebrew respectively.
+
 ## [1.2.5] - 2021-07-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 default = ["wgpu"]
 wgpu = ["ajour-widgets/wgpu", "iced/wgpu", "iced/default_system_font"]
 opengl = ["ajour-widgets/opengl", "iced/glow", "iced/glow_default_system_font"]
+no-self-update = ["ajour-core/no-self-update"]
 
 [dependencies]
 ajour-core = { version = "1.2.5", path = "crates/core", features=['gui'] }

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ DMG_DIR = $(RELEASE_DIR)/osx
 
 OPENGL ?=
 MACOS ?=
+NOSELFUPDATE ?=
 
 ifdef MACOS
   ENV :=MACOSX_DEPLOYMENT_TARGET="10.11"
@@ -35,6 +36,10 @@ else
   DMG_NAME :=ajour.dmg
   APPIMAGE_NAME :=ajour.AppImage
   FEATURE_FLAG :=
+endif
+
+ifdef NOSELFUPDATE
+  FEATURE_FLAG +=--features no-self-update
 endif
 
 vpath $(TARGET) $(RELEASE_DIR)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [features]
 default = []
 gui = ['iced_native']
+no-self-update = []
 
 [[bin]]
 name = "fingerprint_addon"

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -485,7 +485,7 @@ impl Addon {
     fn is_updatable_by_version_comparison(&self, remote_package: &RemotePackage) -> bool {
         if let Some(version) = self.version() {
             let srv = strip_non_digits(&remote_package.version);
-            let slv = strip_non_digits(&version);
+            let slv = strip_non_digits(version);
 
             return !slv.contains(&srv);
         }
@@ -584,13 +584,13 @@ impl PartialEq for Addon {
 
 impl PartialOrd for Addon {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.title().cmp(&other.title()))
+        Some(self.title().cmp(other.title()))
     }
 }
 
 impl Ord for Addon {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.title().cmp(&other.title())
+        self.title().cmp(other.title())
     }
 }
 

--- a/crates/core/src/cache.rs
+++ b/crates/core/src/cache.rs
@@ -166,7 +166,7 @@ pub async fn remove_addon_entries_with_missing_folders(
         .iter()
         .cloned()
         .enumerate()
-        .filter(|(_, entry)| !entry.folder_names.iter().all(|f| folder_names.contains(&f)))
+        .filter(|(_, entry)| !entry.folder_names.iter().all(|f| folder_names.contains(f)))
         .map(|(idx, _)| idx)
         .collect::<Vec<_>>();
 

--- a/crates/core/src/fs/addon.rs
+++ b/crates/core/src/fs/addon.rs
@@ -118,10 +118,7 @@ pub async fn install_addon(
     // Cleanup
     std::fs::remove_file(&zip_path)?;
 
-    let mut addon_folders: Vec<_> = toc_files
-        .iter()
-        .filter_map(|p| parse_toc_path(&p))
-        .collect();
+    let mut addon_folders: Vec<_> = toc_files.iter().filter_map(|p| parse_toc_path(p)).collect();
     addon_folders.sort();
     // Needed since multi-toc can now insert folder name more than once
     addon_folders.dedup();
@@ -195,7 +192,7 @@ mod test {
             files.push(path);
         }
 
-        delete_saved_variables(&folders, &root).unwrap();
+        delete_saved_variables(&folders, root).unwrap();
 
         let mut exists = 0;
         for file in files {

--- a/crates/core/src/fs/theme.rs
+++ b/crates/core/src/fs/theme.rs
@@ -48,7 +48,7 @@ pub async fn import_theme(url: String) -> Result<(String, Vec<Theme>), ThemeErro
 
     let query = uri.query().ok_or(ThemeError::MissingQuery)?;
 
-    let theme = serde_urlencoded::from_str::<Vec<(String, String)>>(&query)?
+    let theme = serde_urlencoded::from_str::<Vec<(String, String)>>(query)?
         .into_iter()
         .find(|(name, _)| name == "theme")
         .map(|(_, theme_json)| serde_json::from_str::<Theme>(&theme_json))

--- a/crates/core/src/repository/backend/curse.rs
+++ b/crates/core/src/repository/backend/curse.rs
@@ -183,7 +183,7 @@ pub(crate) async fn batch_fetch_repo_packages(
         return Ok(curse_repo_packages);
     }
 
-    let mut curse_packages = curse::fetch_remote_packages_by_ids(&curse_ids).await?;
+    let mut curse_packages = curse::fetch_remote_packages_by_ids(curse_ids).await?;
 
     if let Some(fingerprint_info) = fingerprint_info {
         // Get repo packages from fingerprint exact matches

--- a/crates/core/src/repository/backend/hub.rs
+++ b/crates/core/src/repository/backend/hub.rs
@@ -93,7 +93,7 @@ pub(crate) async fn batch_fetch_repo_packages(
         return Ok(hub_repo_packages);
     }
 
-    let hub_packages = hub::fetch_remote_packages(flavor, &hub_ids).await?;
+    let hub_packages = hub::fetch_remote_packages(flavor, hub_ids).await?;
 
     hub_repo_packages.extend(
         hub_packages

--- a/crates/core/src/repository/backend/tukui.rs
+++ b/crates/core/src/repository/backend/tukui.rs
@@ -158,7 +158,7 @@ pub(crate) async fn batch_fetch_repo_packages(
 
     let fetch_tasks: Vec<_> = tukui_ids
         .iter()
-        .map(|id| tukui::fetch_remote_package(&id, &flavor))
+        .map(|id| tukui::fetch_remote_package(id, &flavor))
         .collect();
 
     tukui_repo_packages.extend(

--- a/crates/core/src/repository/backend/wowi.rs
+++ b/crates/core/src/repository/backend/wowi.rs
@@ -97,7 +97,7 @@ pub(crate) async fn batch_fetch_repo_packages(
         return Ok(wowi_repo_packages);
     }
 
-    let wowi_packages = wowi::fetch_remote_packages(&wowi_ids).await?;
+    let wowi_packages = wowi::fetch_remote_packages(wowi_ids).await?;
 
     wowi_repo_packages.extend(
         wowi_packages

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -331,25 +331,12 @@ mod tests {
         let root_alternate_path = PathBuf::from(r"/Applications/Wow");
         let root_path = PathBuf::from(r"/Applications/World of Warcraft");
 
-        assert_eq!(
-            root_path.eq(&wow_path_resolution(Some(classic_addon_path)).unwrap()),
-            true
-        );
-        assert_eq!(
-            root_path.eq(&wow_path_resolution(Some(retail_addon_path)).unwrap()),
-            true
-        );
-        assert_eq!(
-            root_path.eq(&wow_path_resolution(Some(retail_interface_path)).unwrap()),
-            true
-        );
-        assert_eq!(
-            root_path.eq(&wow_path_resolution(Some(classic_interface_path)).unwrap()),
-            true
-        );
-        assert_eq!(
+        assert!(root_path.eq(&wow_path_resolution(Some(classic_addon_path)).unwrap()),);
+        assert!(root_path.eq(&wow_path_resolution(Some(retail_addon_path)).unwrap()),);
+        assert!(root_path.eq(&wow_path_resolution(Some(retail_interface_path)).unwrap()),);
+        assert!(root_path.eq(&wow_path_resolution(Some(classic_interface_path)).unwrap()),);
+        assert!(
             root_alternate_path.eq(&wow_path_resolution(Some(classic_alternate_path)).unwrap()),
-            true
         );
     }
 

--- a/crates/widgets/src/renderer/table_row.rs
+++ b/crates/widgets/src/renderer/table_row.rs
@@ -31,7 +31,7 @@ where
         };
 
         let (content, mouse_interaction) =
-            content.draw(self, &defaults, content_layout, cursor_position, viewport);
+            content.draw(self, defaults, content_layout, cursor_position, viewport);
 
         (
             if style.background.is_some() {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2051,10 +2051,10 @@ impl Default for ScaleState {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone)]
 pub enum BackupFolderKind {
     AddOns,
-    #[allow(clippy::upper_case_acronyms)]
     WTF,
     Config,
     Screenshots,

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2721,7 +2721,7 @@ fn sort_addons(
             addons.sort_by(|a, b| {
                 a.version()
                     .cmp(&b.version())
-                    .then_with(|| a.title().cmp(&b.title()))
+                    .then_with(|| a.title().cmp(b.title()))
             });
         }
         (ColumnKey::LocalVersion, SortDirection::Desc) => {
@@ -2729,14 +2729,14 @@ fn sort_addons(
                 a.version()
                     .cmp(&b.version())
                     .reverse()
-                    .then_with(|| a.title().cmp(&b.title()))
+                    .then_with(|| a.title().cmp(b.title()))
             });
         }
         (ColumnKey::RemoteVersion, SortDirection::Asc) => {
             addons.sort_by(|a, b| {
                 a.relevant_release_package(global_release_channel)
                     .cmp(&b.relevant_release_package(global_release_channel))
-                    .then_with(|| a.cmp(&b))
+                    .then_with(|| a.cmp(b))
             });
         }
         (ColumnKey::RemoteVersion, SortDirection::Desc) => {
@@ -2744,14 +2744,14 @@ fn sort_addons(
                 a.relevant_release_package(global_release_channel)
                     .cmp(&b.relevant_release_package(global_release_channel))
                     .reverse()
-                    .then_with(|| a.cmp(&b))
+                    .then_with(|| a.cmp(b))
             });
         }
         (ColumnKey::Status, SortDirection::Asc) => {
-            addons.sort_by(|a, b| a.state.cmp(&b.state).then_with(|| a.cmp(&b)));
+            addons.sort_by(|a, b| a.state.cmp(&b.state).then_with(|| a.cmp(b)));
         }
         (ColumnKey::Status, SortDirection::Desc) => {
-            addons.sort_by(|a, b| a.state.cmp(&b.state).reverse().then_with(|| a.cmp(&b)));
+            addons.sort_by(|a, b| a.state.cmp(&b.state).reverse().then_with(|| a.cmp(b)));
         }
         (ColumnKey::Channel, SortDirection::Asc) => addons.sort_by(|a, b| {
             a.release_channel
@@ -2941,7 +2941,7 @@ fn sort_auras(auras: &mut [Aura], sort_direction: SortDirection, column_key: Aur
             auras.sort_by(|a, b| {
                 a.installed_symver()
                     .cmp(&b.installed_symver())
-                    .then_with(|| a.name().cmp(&b.name()))
+                    .then_with(|| a.name().cmp(b.name()))
             });
         }
         (AuraColumnKey::LocalVersion, SortDirection::Desc) => {
@@ -2949,29 +2949,29 @@ fn sort_auras(auras: &mut [Aura], sort_direction: SortDirection, column_key: Aur
                 a.installed_symver()
                     .cmp(&b.installed_symver())
                     .reverse()
-                    .then_with(|| a.name().cmp(&b.name()))
+                    .then_with(|| a.name().cmp(b.name()))
             });
         }
         (AuraColumnKey::RemoteVersion, SortDirection::Asc) => {
             auras.sort_by(|a, b| {
                 a.remote_symver()
-                    .cmp(&b.remote_symver())
-                    .then_with(|| a.name().cmp(&b.name()))
+                    .cmp(b.remote_symver())
+                    .then_with(|| a.name().cmp(b.name()))
             });
         }
         (AuraColumnKey::RemoteVersion, SortDirection::Desc) => {
             auras.sort_by(|a, b| {
                 a.remote_symver()
-                    .cmp(&b.remote_symver())
+                    .cmp(b.remote_symver())
                     .reverse()
-                    .then_with(|| a.name().cmp(&b.name()))
+                    .then_with(|| a.name().cmp(b.name()))
             });
         }
         (AuraColumnKey::Author, SortDirection::Asc) => {
-            auras.sort_by(|a, b| a.author().cmp(&b.author()))
+            auras.sort_by(|a, b| a.author().cmp(b.author()))
         }
         (AuraColumnKey::Author, SortDirection::Desc) => {
-            auras.sort_by(|a, b| a.author().cmp(&b.author()).reverse())
+            auras.sort_by(|a, b| a.author().cmp(b.author()).reverse())
         }
         (AuraColumnKey::Type, SortDirection::Asc) => auras.sort_by(|a, b| a.kind().cmp(&b.kind())),
         (AuraColumnKey::Type, SortDirection::Desc) => {
@@ -3018,10 +3018,10 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
             .filter_map(|a| {
                 if let Some(query) = &query {
                     let title_score = fuzzy_matcher
-                        .fuzzy_match(&a.name, &query)
+                        .fuzzy_match(&a.name, query)
                         .unwrap_or_default();
                     let description_score = fuzzy_matcher
-                        .fuzzy_match(&a.summary, &query)
+                        .fuzzy_match(&a.summary, query)
                         .unwrap_or_default()
                         / 2;
 
@@ -3051,7 +3051,7 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
         let mut catalog_rows = if query.is_some() {
             // If a query is defined, the default sort is the fuzzy match score
             catalog_rows_and_score.sort_by(|(addon_a, score_a), (addon_b, score_b)| {
-                score_a.cmp(&score_b).reverse().then_with(|| {
+                score_a.cmp(score_b).reverse().then_with(|| {
                     addon_a
                         .addon
                         .number_of_downloads


### PR DESCRIPTION
Resolves #704

## Proposed Changes
  - Adds a new cargo feature flag `no-self-update`. When used, Ajour won't check for newer updates.
  - Adds 2 new release assets, one for Windows and Macos, both with this feature activated. These can be picked up by Chocolatey & Homebrew respectively.

## Checklist

- [ ] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
