### PR TITLE
Fix/tab no modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and `Removed`.
 - Adds 2 new release assets, one for Windows and Macos, both with this feature
   activated. These can be picked up by Chocolatey & Homebrew respectively.
 
+### Fixed
+
+- Fixed bug where `alt+tab` would change tabs in Ajour.
+
 ## [1.2.5] - 2021-07-26
 
 ### Fixed

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2376,7 +2376,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
                 _ => (),
             },
-            iced::keyboard::KeyCode::Tab => {
+            iced::keyboard::KeyCode::Tab if !modifiers.alt => {
                 let flavor = ajour.config.wow.flavor;
 
                 if modifiers.control {


### PR DESCRIPTION
Resolves #

## Proposed Changes
  - Alt-tabbing shouldn't cause Ajour to change tabs

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
