### PR TITLE
Fix/dialog

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,14 +1,14 @@
 on:
   push:
     paths:
-      - "**.rs"
-      - "Cargo.lock"
-      - "Cargo.toml"
+    - '**.rs'
+    - 'Cargo.lock'
+    - 'Cargo.toml'
   pull_request:
     paths:
-      - "**.rs"
-      - "Cargo.lock"
-      - "Cargo.toml"
+    - '**.rs'
+    - 'Cargo.lock'
+    - 'Cargo.toml'
 
 name: Continuous-integration
 
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: sudo apt install libgtk-3-dev
       - uses: actions/cache@v2
         with:
           path: |
@@ -46,8 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: sudo apt install libgtk-3-dev
       - uses: actions/cache@v2
         with:
           path: |
@@ -90,8 +86,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: sudo apt install libgtk-3-dev
       - uses: actions/cache@v2
         with:
           path: |
@@ -109,7 +103,7 @@ jobs:
         with:
           command: clippy
           args: --all -- -D warnings
-
+  
   poeditor:
     name: POEditor
     runs-on: ubuntu-latest

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -27,11 +27,11 @@ jobs:
             binary_path: target/release/ajour.exe
 
           - target: linux-wgpu
-            os: ubuntu-18.04
+            os: ubuntu-16.04
             make: make appimage
             binary_path: ajour.AppImage
           - target: linux-opengl
-            os: ubuntu-18.04
+            os: ubuntu-16.04
             make: make appimage OPENGL=1
             binary_path: ajour-opengl.AppImage
 
@@ -66,12 +66,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Install dependencies
-        if: ${{ matrix.target.os == 'ubuntu-18.04' }}
-        run: sudo apt install libgtk-3-dev
-
       - name: Do we need linuxdeploy?
-        if: ${{ matrix.target.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.target.os == 'ubuntu-16.04' }}
         run: |
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "json-gettext",
  "log",
  "log-panics",
+ "native-dialog",
  "num-format",
  "once_cell",
  "open",
@@ -2561,6 +2562,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-dialog"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d689b01017db3e350e0e9798d233cca9ad3bf810e7c02b9b55ec06b9ee7dbd8a"
+dependencies = [
+ "cocoa 0.24.0",
+ "dirs-next",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "once_cell",
+ "raw-window-handle",
+ "thiserror",
+ "wfd",
+ "which",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ndk"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4402,6 +4422,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wfd"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e713040b67aae5bf1a0ae3e1ebba8cc29ab2b90da9aa1bff6e09031a8a41d7a8"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "wgpu"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4470,6 +4500,17 @@ dependencies = [
  "log",
  "wgpu",
  "zerocopy",
+]
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ iced_native = { version = "0.4.0" }
 async-std = "1.6.2"
 isahc = { version = "0.9.6", features = ["json"] }
 image = "0.23.8"
-rfd = "0.4.0"
 opener = "0.4.1"
 chrono = { version = "0.4", features = ['serde'] }
 log = "0.4"
@@ -49,6 +48,11 @@ once_cell = "1.6.0"
 serde = { version = "1.0.114", features=['derive'] }
 serde_json = "1.0.57"
 
+[target.'cfg(target_os =  "linux")'.dependencies]
+native-dialog = "0.5.5"
+
+[target.'cfg(not(target_os =  "linux"))'.dependencies]
+rfd = "0.4.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
Use `native-dialog` for linux and `rfd` for windows / mac. `native-dialog` panics on macos, hence the change. But `rfd` adds too many additional dependencies for linux, so we want to keep `native-dialog`
