### PR TITLE
feat: retry buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Added
+
+- A new retry button will appear alongside an error message if one of the API servers
+  is down. This new button should make it easier to try fetching the data again
+  instead of relaunching the application.
+
 ## [1.3.0] - 2021-08-05
 
 ### Packaging

--- a/src/gui/element/status.rs
+++ b/src/gui/element/status.rs
@@ -1,7 +1,6 @@
 use {
     super::{DEFAULT_FONT_SIZE, DEFAULT_PADDING},
     crate::gui::{style, Interaction, Message},
-    crate::localization::localized_string,
     ajour_core::theme::ColorPalette,
     iced::{
         button, Align, Button, Column, Container, Element, HorizontalAlignment, Length, Space, Text,
@@ -13,7 +12,7 @@ pub fn data_container<'a>(
     color_palette: ColorPalette,
     title: &str,
     description: &str,
-    onboarding_directory_btn_state: Option<&'a mut button::State>,
+    button: Option<(&'a mut button::State, String, Interaction)>,
 ) -> Container<'a, Message> {
     let title = Text::new(title)
         .size(DEFAULT_FONT_SIZE)
@@ -36,20 +35,18 @@ pub fn data_container<'a>(
         .push(Space::new(Length::Units(0), Length::Units(2)))
         .push(description_container);
 
-    if let Some(btn_state) = onboarding_directory_btn_state {
-        let onboarding_button_title_container =
-            Container::new(Text::new(localized_string("select-directory")).size(DEFAULT_FONT_SIZE))
-                .center_x()
-                .align_x(Align::Center);
-        let onboarding_button: Element<Interaction> =
-            Button::new(btn_state, onboarding_button_title_container)
-                .style(style::DefaultButton(color_palette))
-                .on_press(Interaction::SelectWowDirectory(None))
-                .into();
+    if let Some((state, title, interaction)) = button {
+        let title_container = Container::new(Text::new(title).size(DEFAULT_FONT_SIZE))
+            .center_x()
+            .align_x(Align::Center);
+        let button: Element<Interaction> = Button::new(state, title_container)
+            .style(style::DefaultButton(color_palette))
+            .on_press(interaction)
+            .into();
 
         colum = colum
             .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
-            .push(onboarding_button.map(Message::Interaction))
+            .push(button.map(Message::Interaction))
             .align_items(Align::Center);
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -256,7 +256,6 @@ pub struct Ajour {
     backup_state: BackupState,
     column_settings: ColumnSettings,
     catalog_column_settings: CatalogColumnSettings,
-    onboarding_directory_btn_state: button::State,
     catalog: Option<Catalog>,
     install_addons: HashMap<Flavor, Vec<InstallAddon>>,
     catalog_last_updated: Option<DateTime<Utc>>,
@@ -282,6 +281,10 @@ pub struct Ajour {
     pending_confirmation: Option<Confirm>,
     zstd_compression_level_slider_state: slider::State,
     share_state: ShareState,
+    onboarding_status_button_state: button::State,
+    addons_status_button_state: button::State,
+    weakauras_status_button_state: button::State,
+    catalog_status_button_state: button::State,
 }
 
 impl Default for Ajour {
@@ -315,7 +318,6 @@ impl Default for Ajour {
             backup_state: Default::default(),
             column_settings: Default::default(),
             catalog_column_settings: Default::default(),
-            onboarding_directory_btn_state: Default::default(),
             catalog: None,
             install_addons: Default::default(),
             catalog_last_updated: None,
@@ -350,6 +352,10 @@ impl Default for Ajour {
             pending_confirmation: None,
             zstd_compression_level_slider_state: Default::default(),
             share_state: Default::default(),
+            onboarding_status_button_state: Default::default(),
+            addons_status_button_state: Default::default(),
+            weakauras_status_button_state: Default::default(),
+            catalog_status_button_state: Default::default(),
         }
     }
 }
@@ -1090,14 +1096,22 @@ impl Application for Ajour {
                             color_palette,
                             &error_title,
                             &error_description,
-                            None,
+                            Some((
+                                &mut self.addons_status_button_state,
+                                localized_string("retry"),
+                                Interaction::Refresh(Mode::MyAddons(flavor)),
+                            )),
                         ))
                     }
                     None => Some(element::status::data_container(
                         color_palette,
                         &localized_string("setup-ajour-title")[..],
                         &localized_string("setup-ajour-description")[..],
-                        Some(&mut self.onboarding_directory_btn_state),
+                        Some((
+                            &mut self.onboarding_status_button_state,
+                            localized_string("select-directory"),
+                            Interaction::SelectWowDirectory(None),
+                        )),
                     )),
                 }
             }
@@ -1151,7 +1165,11 @@ impl Application for Ajour {
                             color_palette,
                             &error_title,
                             &error_description,
-                            None,
+                            Some((
+                                &mut self.weakauras_status_button_state,
+                                localized_string("retry"),
+                                Interaction::Refresh(Mode::MyWeakAuras(flavor)),
+                            )),
                         ))
                     }
                     None => Some(element::status::data_container(
@@ -1184,7 +1202,11 @@ impl Application for Ajour {
                             color_palette,
                             &error_title,
                             &error_description,
-                            None,
+                            Some((
+                                &mut self.catalog_status_button_state,
+                                localized_string("retry"),
+                                Interaction::Refresh(Mode::Catalog),
+                            )),
                         ))
                     }
                     _ => None,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -281,10 +281,7 @@ pub struct Ajour {
     pending_confirmation: Option<Confirm>,
     zstd_compression_level_slider_state: slider::State,
     share_state: ShareState,
-    onboarding_status_button_state: button::State,
-    addons_status_button_state: button::State,
-    weakauras_status_button_state: button::State,
-    catalog_status_button_state: button::State,
+    status_button_state: button::State,
 }
 
 impl Default for Ajour {
@@ -352,10 +349,7 @@ impl Default for Ajour {
             pending_confirmation: None,
             zstd_compression_level_slider_state: Default::default(),
             share_state: Default::default(),
-            onboarding_status_button_state: Default::default(),
-            addons_status_button_state: Default::default(),
-            weakauras_status_button_state: Default::default(),
-            catalog_status_button_state: Default::default(),
+            status_button_state: Default::default(),
         }
     }
 }
@@ -1097,7 +1091,7 @@ impl Application for Ajour {
                             &error_title,
                             &error_description,
                             Some((
-                                &mut self.addons_status_button_state,
+                                &mut self.status_button_state,
                                 localized_string("retry"),
                                 Interaction::Refresh(Mode::MyAddons(flavor)),
                             )),
@@ -1108,7 +1102,7 @@ impl Application for Ajour {
                         &localized_string("setup-ajour-title")[..],
                         &localized_string("setup-ajour-description")[..],
                         Some((
-                            &mut self.onboarding_status_button_state,
+                            &mut self.status_button_state,
                             localized_string("select-directory"),
                             Interaction::SelectWowDirectory(None),
                         )),
@@ -1166,7 +1160,7 @@ impl Application for Ajour {
                             &error_title,
                             &error_description,
                             Some((
-                                &mut self.weakauras_status_button_state,
+                                &mut self.status_button_state,
                                 localized_string("retry"),
                                 Interaction::Refresh(Mode::MyWeakAuras(flavor)),
                             )),
@@ -1203,7 +1197,7 @@ impl Application for Ajour {
                             &error_title,
                             &error_description,
                             Some((
-                                &mut self.catalog_status_button_state,
+                                &mut self.status_button_state,
                                 localized_string("retry"),
                                 Interaction::Refresh(Mode::Catalog),
                             )),

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -221,6 +221,14 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                         }
                     }
                 }
+                Mode::Catalog => {
+                    ajour.catalog = None;
+                    ajour.state.insert(Mode::Catalog, State::Loading);
+                    return Ok(Command::perform(
+                        catalog_download_latest_or_use_cache(),
+                        Message::CatalogDownloaded,
+                    ));
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
Resolves #717 

## Proposed Changes
  - Adds a retry button under the error to try again.

<img width="712" alt="Screenshot 2021-08-12 at 22 27 24" src="https://user-images.githubusercontent.com/2248455/129265535-035adb17-b45a-4b08-8f32-6574da5a4aed.png">

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
