### PR TITLE
Option to disable keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Added
+
+- Option to disable keybindings in Ajour.
+
+### Fixed
+
+- Resolved a issue where keybindings would trigger with modifiers.
+
 ## [1.3.1] - 2021-09-12
 
 ### Added

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -63,6 +63,9 @@ pub struct Config {
     #[serde(default = "default_true")]
     pub alternating_row_colors: bool,
 
+    #[serde(default = "default_true")]
+    pub is_keybindings_enabled: bool,
+
     #[serde(default)]
     pub language: Language,
 

--- a/locale/en.json
+++ b/locale/en.json
@@ -148,5 +148,6 @@
     "all-sources": "All Sources",
     "share-addons-title": "Import and Export a YAML file of your addons",
     "share-addons-import": "Import",
-    "share-addons-export": "Export"
+    "share-addons-export": "Export",
+    "keybindings-enabled": "Enable keybindings"
 }

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -733,6 +733,23 @@ pub fn data_container<'a, 'b>(
         Column::new().push(checkbox_container)
     };
 
+    let enabled_keybindings_column = {
+        let checkbox = Checkbox::new(
+            config.is_keybindings_enabled,
+            localized_string("keybindings-enabled"),
+            Interaction::KeybindingsToggle,
+        )
+        .style(style::DefaultCheckbox(color_palette))
+        .text_size(DEFAULT_FONT_SIZE)
+        .spacing(5);
+
+        let checkbox: Element<Interaction> = checkbox.into();
+
+        let checkbox_container = Container::new(checkbox.map(Message::Interaction))
+            .style(style::NormalBackgroundContainer(color_palette));
+        Column::new().push(checkbox_container)
+    };
+
     let self_update_channel_container = {
         let channel_title = Container::new(
             Text::new(localized_string("ajour-update-channel")).size(DEFAULT_FONT_SIZE),
@@ -853,6 +870,8 @@ pub fn data_container<'a, 'b>(
         .push(self_update_channel_container)
         .push(Space::new(Length::Units(0), Length::Units(10)))
         .push(config_column)
+        .push(Space::new(Length::Units(0), Length::Units(10)))
+        .push(enabled_keybindings_column)
         .push(Space::new(Length::Units(0), Length::Units(10)))
         .push(auto_update_column);
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -164,6 +164,7 @@ pub enum Interaction {
     PickBackupCompressionFormat(CompressionFormat),
     PickLocalizationLanguage(Language),
     AlternatingRowColorToggled(bool),
+    KeybindingsToggle(bool),
     ResetColumns,
     ToggleDeleteSavedVariables(bool),
     AddonsQuery(String),

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2308,6 +2308,12 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             ajour.config.alternating_row_colors = is_set;
             let _ = ajour.config.save();
         }
+        Message::Interaction(Interaction::KeybindingsToggle(is_set)) => {
+            log::debug!("Interaction::KeybindingsToggle(is_set: {})", is_set,);
+
+            ajour.config.is_keybindings_enabled = is_set;
+            let _ = ajour.config.save();
+        }
         Message::Interaction(Interaction::ExportAddons) => {
             log::debug!("Interaction::ExportAddons");
 
@@ -2427,48 +2433,61 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::RuntimeEvent(iced_native::Event::Keyboard(
             iced_native::keyboard::Event::KeyReleased {
                 key_code,
-                modifiers: _,
+                modifiers,
             },
-        )) => match key_code {
-            iced::keyboard::KeyCode::A => {
-                let flavor = ajour.config.wow.flavor;
-                ajour.mode = Mode::MyAddons(flavor);
+        )) => {
+            // Bail out of keybindings if keybindings is diabled, or we are
+            // pressing any modifiers.
+            if !ajour.config.is_keybindings_enabled
+                || modifiers != iced::keyboard::Modifiers::default()
+            {
+                return Ok(Command::none());
             }
-            iced::keyboard::KeyCode::C => {
-                ajour.mode = Mode::Catalog;
-            }
-            iced::keyboard::KeyCode::R => {
-                let mode = ajour.mode.clone();
-                return handle_message(ajour, Message::Interaction(Interaction::Refresh(mode)));
-            }
-            iced::keyboard::KeyCode::S => {
-                ajour.mode = Mode::Settings;
-            }
-            iced::keyboard::KeyCode::U => {
-                let mode = ajour.mode.clone();
-                return handle_message(ajour, Message::Interaction(Interaction::UpdateAll(mode)));
-            }
-            iced::keyboard::KeyCode::W => {
-                let flavor = ajour.config.wow.flavor;
-                ajour.mode = Mode::MyWeakAuras(flavor);
-            }
-            iced::keyboard::KeyCode::I => {
-                ajour.mode = Mode::Install;
-            }
-            iced::keyboard::KeyCode::Escape => match ajour.mode {
-                Mode::Settings | Mode::About => {
-                    ajour.mode = Mode::MyAddons(ajour.config.wow.flavor);
+
+            match key_code {
+                iced::keyboard::KeyCode::A => {
+                    let flavor = ajour.config.wow.flavor;
+                    ajour.mode = Mode::MyAddons(flavor);
                 }
-                Mode::MyAddons(_) => {
-                    ajour.addons_search_state.query = None;
+                iced::keyboard::KeyCode::C => {
+                    ajour.mode = Mode::Catalog;
                 }
-                Mode::Catalog => {
-                    ajour.catalog_search_state.query = None;
+                iced::keyboard::KeyCode::R => {
+                    let mode = ajour.mode.clone();
+                    return handle_message(ajour, Message::Interaction(Interaction::Refresh(mode)));
                 }
+                iced::keyboard::KeyCode::S => {
+                    ajour.mode = Mode::Settings;
+                }
+                iced::keyboard::KeyCode::U => {
+                    let mode = ajour.mode.clone();
+                    return handle_message(
+                        ajour,
+                        Message::Interaction(Interaction::UpdateAll(mode)),
+                    );
+                }
+                iced::keyboard::KeyCode::W => {
+                    let flavor = ajour.config.wow.flavor;
+                    ajour.mode = Mode::MyWeakAuras(flavor);
+                }
+                iced::keyboard::KeyCode::I => {
+                    ajour.mode = Mode::Install;
+                }
+                iced::keyboard::KeyCode::Escape => match ajour.mode {
+                    Mode::Settings | Mode::About => {
+                        ajour.mode = Mode::MyAddons(ajour.config.wow.flavor);
+                    }
+                    Mode::MyAddons(_) => {
+                        ajour.addons_search_state.query = None;
+                    }
+                    Mode::Catalog => {
+                        ajour.catalog_search_state.query = None;
+                    }
+                    _ => (),
+                },
                 _ => (),
-            },
-            _ => (),
-        },
+            }
+        }
         Message::Interaction(Interaction::PickBackupCompressionFormat(format)) => {
             log::debug!("Interaction::PickBackupCompressionFormat({:?})", format);
             ajour.config.compression_format = format;


### PR DESCRIPTION
* Resolves issue where people don't want any keybindings in ajour.
* Resolves issue where keybind ALT + S would trigger S meaning that all modifiers was ignored. This caused problems for eg. Windows Snippet etc.

## Checklist

- [X] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
