### PR TITLE
Updated regex to handle new toc files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Better handling of the new TOC format with flavor in the filename.
+
 ## [1.3.1] - 2021-09-12
 
 ### Added

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -1033,7 +1033,7 @@ static RE_PARSING_PATTERNS: Lazy<ParsingPatterns> = Lazy::new(|| {
     ParsingPatterns {
         extra_inclusion_regex: Regex::new(r#"(?i)^[^/\\]+[/\\]Bindings\.xml$"#).unwrap(),
         initial_inclusion_regex: Regex::new(
-            r#"(?i)^([^/\\]+)[/\\]\1(-mainline|-bcc|-classic)?\.toc$"#,
+            r#"(?i)^([^/\\]+)[/\\]\1([-|_](mainline|bcc|tbc|classic|vanilla))?\.toc$"#,
         )
         .unwrap(),
         file_parsing_regex,


### PR DESCRIPTION
## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
